### PR TITLE
chore(prompts): enforce release sync before main PR creation

### DIFF
--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -1,41 +1,47 @@
 ---
 name: "PR"
-description: "Create a pull request with smart target selection: default current branch -> development, or --master for development -> main."
-argument-hint: "Optional: PR intent/title hint. Prefix with 'draft' for draft PR or '--master' for release PR (development -> main)."
+description: "Create a pull request with smart target selection: default current branch -> development, or --main/--master for development -> main."
+argument-hint: "Optional: PR intent/title hint. Prefix with 'draft' for draft PR or '--main' (alias '--master') for release PR (development -> main)."
 agent: "Git Commit Specialist"
 ---
 Start the pull request workflow immediately using the Git Commit Specialist agent.
 
-User intent: ${input:Optional PR intent/title hint — prefix with 'draft' and/or '--master'}
+User intent: ${input:Optional PR intent/title hint — prefix with 'draft' and/or '--main' (or '--master')}
 
 ## Mode Selection
-- If user intent contains `--master`, run in release mode:
+- If user intent contains `--main` or `--master`, run in release mode:
   - Head branch: `development`
   - Base branch: `main`
-  - Remove `--master` from the final PR title/body text
+   - Remove `--main`/`--master` from the final PR title/body text
 - Otherwise run in development mode:
   - Head branch: current checked-out branch
   - Base branch: `development`
 
 ## Target Rules
 - Development mode: never open a PR from `main`, `master`, `develop`, or `development` to `development`; if currently on one of these, ask for one concise clarification before proceeding.
-- Release mode (`--master`): always create PR from `development` to `main` unless user explicitly overrides.
+- Release mode (`--main` or `--master`): always create PR from `development` to `main` unless user explicitly overrides.
 
 ## PR Execution Rules
 1. Run `git status --short --branch` and confirm there are no merge conflicts.
 2. Resolve head/base branches from Mode Selection.
-3. Verify head branch is pushed to origin; if not, push with upstream first.
-4. Compare head against base and summarize changes (commits/files) for the PR context.
-5. Propose up to 3 PR titles if intent is ambiguous; otherwise use the best clear title.
-6. Build a concise PR body with:
+3. If release mode (`--main`/`--master`):
+   - Capture current branch name so it can be restored after sync.
+   - Run `git switch development && git pull --ff-only origin development`.
+   - Run `git switch main && git pull --ff-only origin main`.
+   - Return to previous branch unless it is `development` or `main`.
+4. Verify head branch is pushed to origin; if not, push with upstream first.
+5. Compare head against base and summarize changes (commits/files) for the PR context.
+6. If release mode (`--main`/`--master`), generate PR title/body only from the real `main...development` diff after pulls.
+7. Propose up to 3 PR titles if intent is ambiguous; otherwise use the best clear title.
+8. Build a concise PR body with:
    - Summary
    - What changed
    - Validation performed
    - Risks/notes
-7. Create the PR using resolved head/base branches:
+9. Create the PR using resolved head/base branches:
    - Default: ready PR
    - If user intent includes `draft`, create as draft
-8. Return:
+10. Return:
    - Base and head branches
    - Final title
    - PR URL
@@ -45,4 +51,5 @@ User intent: ${input:Optional PR intent/title hint — prefix with 'draft' and/o
 ## Safety Rules
 - If there are uncommitted changes that would affect PR accuracy, ask one concise clarification question before creating the PR.
 - In development mode: if `development` does not exist on remote, ask one concise clarification question and suggest `develop` as fallback.
-- In release mode (`--master`): if `main` or `development` does not exist on remote, ask one concise clarification question before proceeding.
+- In release mode (`--main` or `--master`): if `main` or `development` does not exist on remote, ask one concise clarification question before proceeding.
+- In release mode (`--main` or `--master`): if `git pull --ff-only` fails on either `main` or `development`, stop and ask one concise clarification question before creating the PR.


### PR DESCRIPTION
## Summary
Hardens PR prompt behavior for release mode so generated release PR descriptions come from an up-to-date branch comparison.

## What changed
- Updated PR prompt rules to require syncing both development and main before creating a release PR in --main/--master mode.
- Added explicit rule to generate release PR title/body from the real main...development diff after sync.
- Added failure safety: stop and ask for clarification if ff-only pull fails on either branch.

## Validation performed
- Prompt logic validated by workflow run and branch-diff behavior.
- Prior repository validation context for this branch: build passed, lint fails due to missing eslint-plugin-react-you-might-not-need-an-effect dependency.

## Risks / notes
- Scope is limited to prompt behavior; no runtime application code changes.