### PR TITLE
feat(animal): use backend stats for dashboard counters

### DIFF
--- a/src/features/animal/api/animal-api.ts
+++ b/src/features/animal/api/animal-api.ts
@@ -2,6 +2,7 @@ import { axiosHelper } from "@/lib/axios/axios-helper";
 import type { IResponse } from "@/lib/axios";
 import type {
 	IAnimal,
+	IAnimalStatsResponse,
 	IAnimalsCountBySpeciesResponse,
 	IAnimalWithIncludes,
 	ICreateAnimalBulkPayload,
@@ -105,6 +106,13 @@ export const getAnimalsCountBySpecies = ({ language }: { language: string }) =>
 	axiosHelper<IResponse<IAnimalsCountBySpeciesResponse[]>>({
 		method: "get",
 		url: `/animals/dashboard`,
+		urlParams: { language },
+	});
+
+export const getAnimalStats = ({ language }: { language: string }) =>
+	axiosHelper<IResponse<IAnimalStatsResponse>>({
+		method: "get",
+		url: `/animals/stats`,
 		urlParams: { language },
 	});
 

--- a/src/features/animal/api/animal-queries.ts
+++ b/src/features/animal/api/animal-queries.ts
@@ -13,12 +13,14 @@ import {
 	getAnimalById,
 	getAnimalsByFarmId,
 	getAnimalsCountBySpecies,
+	getAnimalStats,
 	searchAnimals,
 } from "@/features/animal/api/animal-api";
 import type {
 	IAnimal,
 	IAnimalListFilters,
 	IAnimalSearchFilters,
+	IAnimalStatsResponse,
 	IAnimalsCountBySpeciesResponse,
 	ICreateAnimalBulkResponse,
 	ICreateAnimalBulkPayload,
@@ -167,6 +169,8 @@ export const animalQueryKeys = {
 	) => [...animalQueryKeys.animalList(farmId, filters), "page", limit] as const,
 	animalById: (animalId: string) =>
 		[...animalQueryKeys.all, "byId", animalId] as const,
+	animalStats: (farmId: string, language: string) =>
+		[...animalQueryKeys.all, "stats", farmId, language] as const,
 	animalsCountBySpecies: (farmId: string, language: string) =>
 		[...animalQueryKeys.all, "countBySpecies", farmId, language] as const,
 	animalSearch: (filters: IAnimalSearchFilters, limit: number) =>
@@ -376,6 +380,10 @@ export const useCreateAnimal = () => {
 			void queryClient.invalidateQueries({
 				queryKey: [...animalQueryKeys.all, "list", farmId],
 			});
+
+			void queryClient.invalidateQueries({
+				queryKey: [...animalQueryKeys.all, "stats", farmId],
+			});
 		},
 	});
 };
@@ -468,6 +476,10 @@ export const useDeleteAnimalById = () => {
 
 			void queryClient.invalidateQueries({
 				queryKey: [...animalQueryKeys.all, "list", farmId],
+			});
+
+			void queryClient.invalidateQueries({
+				queryKey: [...animalQueryKeys.all, "stats", farmId],
 			});
 		},
 	});
@@ -650,7 +662,23 @@ export const useCreateAnimalBulk = () => {
 			void queryClient.invalidateQueries({
 				queryKey: [...animalQueryKeys.all, "countBySpecies", farmId],
 			});
+
+			void queryClient.invalidateQueries({
+				queryKey: [...animalQueryKeys.all, "stats", farmId],
+			});
 		},
+	});
+};
+
+export const useGetAnimalStats = (farmId: string) => {
+	const language = i18next.language.slice(0, 2);
+
+	return useQuery({
+		queryKey: animalQueryKeys.animalStats(farmId, language),
+		queryFn: () => getAnimalStats({ language }),
+		select: (data): IAnimalStatsResponse => data.data,
+		enabled: !!farmId,
+		staleTime: 10000,
 	});
 };
 

--- a/src/features/animal/types/animal-types.ts
+++ b/src/features/animal/types/animal-types.ts
@@ -109,6 +109,11 @@ export interface IAnimalsCountBySpeciesResponse {
 	};
 }
 
+export interface IAnimalStatsResponse {
+	total: number;
+	lastSevenDays: number;
+}
+
 export interface IAnimalListFilters {
 	sex?: IAnimal["sex"] | "";
 	speciesId?: string | "";

--- a/src/routes/_private/_privatelayout/farm/$farmId/dashboard.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/dashboard.tsx
@@ -17,8 +17,10 @@ import {
 	Stethoscope,
 	Heart,
 } from "lucide-react";
-import { useGetAnimalsByFarmId } from "@/features/animal/api/animal-queries";
-import { countAnimalsAddedInPastDays } from "@/features/dashboard/utils/count-animals-added-in-period";
+import {
+	useGetAnimalStats,
+	useGetAnimalsByFarmId,
+} from "@/features/animal/api/animal-queries";
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { NewAnimalModal } from "@/features/animal/components/new-animal-modal/new-animal-modal";
@@ -33,17 +35,16 @@ function RouteComponent() {
 	const { farmId } = useParams({ strict: false });
 	const navigate = useNavigate();
 	const [isAddAnimalOpen, setIsAddAnimalOpen] = useState(false);
-	const { data: animalData, isLoading } = useGetAnimalsByFarmId({
+	const { data: animalData } = useGetAnimalsByFarmId({
 		farmId: farmId!,
 		include: "species.translations,breed",
 		withLanguage: true,
 	});
 
-	const totalAnimals = animalData?.length || 0;
-	const animalsAddedLast7Days = countAnimalsAddedInPastDays(
-		animalData ?? [],
-		7,
-	);
+	const { data: animalStats, isLoading: isAnimalStatsLoading } =
+		useGetAnimalStats(farmId!);
+	const totalAnimals = animalStats?.total ?? 0;
+	const animalsAddedLast7Days = animalStats?.lastSevenDays ?? 0;
 	const healthAlerts =
 		animalData?.filter((animal) => animal.status !== "alive").length || 0;
 	const { t } = useTranslation("dashboard");
@@ -100,9 +101,9 @@ function RouteComponent() {
 								iconColor="text-primary"
 								borderColor="border-l-primary"
 								label={t("resumes.resumeAnimalsCard.label")}
-								value={isLoading ? "..." : totalAnimals}
+								value={isAnimalStatsLoading ? "..." : totalAnimals}
 								trend={
-									!isLoading
+									!isAnimalStatsLoading
 										? {
 												value: t("resumes.resumeAnimalsCard.trendValue", {
 													count: animalsAddedLast7Days,


### PR DESCRIPTION
## Summary
Use the new animals stats endpoint for dashboard counters instead of client-side counting from fetched animal lists.

## What changed
- Added animal stats response type with total and lastSevenDays.
- Added animal API client for GET /animals/stats with required language query param.
- Added React Query key and hook for animal stats.
- Updated dashboard route to read total and last 7 days from the stats query.
- Invalidated animal stats queries after create, bulk create, and delete mutations.

## Validation performed
- npm run build: passed
- npm run lint: failed in this environment due to missing eslint-plugin-react-you-might-not-need-an-effect dependency referenced by eslint config

## Risks / notes
- Dashboard still fetches animal list for health alerts and recent activity; this PR only replaces total and last-7-days counters with server stats.