### PR TITLE
feat(expenses): responsive filter UX with apply flow

### DIFF
--- a/src/features/auth/api/auth-api.ts
+++ b/src/features/auth/api/auth-api.ts
@@ -11,14 +11,20 @@ export const signup = ({ payload }: { payload: ISignUpPayload }) =>
 	axiosHelper<IResponse<ISignUpResponse>>({
 		method: "post",
 		url: "/auth/signup",
-		data: payload,
+		data: {
+			...payload,
+			email: payload.email.trim().toLowerCase(),
+		},
 	});
 
 export const login = ({ payload }: { payload: ILoginPayload }) =>
 	axiosHelper<IResponse<IUser>>({
 		method: "post",
 		url: "/auth/login",
-		data: payload,
+		data: {
+			...payload,
+			email: payload.email.trim().toLowerCase(),
+		},
 	});
 
 export const getUserProfile = () =>

--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -48,6 +48,11 @@ export const LoginForm = () => {
 							<FormLabel>{t("emailInputLabel")}</FormLabel>
 							<FormControl>
 								<Input
+									type="email"
+									autoComplete="email"
+									autoCapitalize="none"
+									autoCorrect="off"
+									spellCheck={false}
 									placeholder={t("emailPlaceholder")}
 									{...field}
 								/>

--- a/src/features/auth/components/sign-up-form.tsx
+++ b/src/features/auth/components/sign-up-form.tsx
@@ -70,6 +70,11 @@ export const SignUpForm = ({
 									</div>
 								) : (
 									<Input
+										type="email"
+										autoComplete="email"
+										autoCapitalize="none"
+										autoCorrect="off"
+										spellCheck={false}
 										placeholder={t("emailPlaceholder")}
 										{...field}
 									/>

--- a/src/features/expense/components/expense-filter-fab.tsx
+++ b/src/features/expense/components/expense-filter-fab.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import type { IExpenseListFilters } from "@/features/expense/types/expense-types";
+import { Filter } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface ExpenseFilterFABProps {
+	filters: Partial<IExpenseListFilters>;
+	onOpen: () => void;
+}
+
+export const ExpenseFilterFAB = ({
+	filters,
+	onOpen,
+}: ExpenseFilterFABProps) => {
+	const { t } = useTranslation("expenses");
+	const activeFilterCount = Object.values(filters).filter(
+		(v) => v !== undefined,
+	).length;
+
+	return (
+		<div className="fixed bottom-20 left-1/2 -translate-x-1/2 z-40 md:hidden">
+			<Button
+				onClick={onOpen}
+				variant={activeFilterCount > 0 ? "default" : "outline"}
+				className="rounded-full px-4 py-2 h-10 gap-2 whitespace-nowrap"
+			>
+				<Filter className="h-4 w-4" />
+				<span className="text-sm font-medium">
+					{t("filters.button", "Filters")}
+				</span>
+				{activeFilterCount > 0 && (
+					<Badge
+						variant="secondary"
+						className="ml-1 h-5 min-w-5 rounded-full px-1.5 text-xs"
+					>
+						{activeFilterCount}
+					</Badge>
+				)}
+			</Button>
+		</div>
+	);
+};

--- a/src/features/expense/components/expense-filter-panel.tsx
+++ b/src/features/expense/components/expense-filter-panel.tsx
@@ -1,0 +1,359 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	expenseCategories,
+	expenseStatuses,
+	paymentMethods,
+	type IExpenseListFilters,
+} from "@/features/expense/types/expense-types";
+import {
+	expenseCategoryLabelKeys,
+	expenseStatusLabelKeys,
+	paymentMethodLabelKeys,
+} from "./expense-labels";
+import { Check } from "lucide-react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+interface ExpenseFilterPanelProps {
+	filters: Partial<IExpenseListFilters>;
+	onChange: (filters: Partial<IExpenseListFilters>) => void;
+	onApply: () => void;
+	onClear: () => void;
+	variant: "toolbar" | "sidebar";
+}
+
+export const ExpenseFilterPanel = ({
+	filters,
+	onChange,
+	onApply,
+	onClear,
+	variant,
+}: ExpenseFilterPanelProps) => {
+	const { t } = useTranslation("expenses");
+
+	const categoryOptions = useMemo(
+		() => [
+			{ label: t("filters.allCategories"), value: "all" },
+			...expenseCategories.map((category) => ({
+				label: t(expenseCategoryLabelKeys[category] as never),
+				value: category,
+			})),
+		],
+		[t],
+	);
+
+	const statusOptions = useMemo(
+		() => [
+			{ label: t("filters.allStatuses"), value: "all" },
+			...expenseStatuses.map((status) => ({
+				label: t(expenseStatusLabelKeys[status] as never),
+				value: status,
+			})),
+		],
+		[t],
+	);
+
+	const paymentMethodOptions = useMemo(
+		() => [
+			{ label: t("filters.allPaymentMethods"), value: "all" },
+			...paymentMethods.map((method) => ({
+				label: t(paymentMethodLabelKeys[method] as never),
+				value: method,
+			})),
+		],
+		[t],
+	);
+
+	const activeFilterCount = Object.values(filters).filter(
+		(value) => value !== undefined,
+	).length;
+
+	const setCategory = (value: string) => {
+		onChange({
+			...filters,
+			category:
+				value === "all"
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["category"]>),
+		});
+	};
+
+	const setStatus = (value: string) => {
+		onChange({
+			...filters,
+			status:
+				value === "all"
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["status"]>),
+		});
+	};
+
+	const toggleStatus = (value: string) => {
+		onChange({
+			...filters,
+			status:
+				filters.status === value
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["status"]>),
+		});
+	};
+
+	const togglePaymentMethod = (value: string) => {
+		onChange({
+			...filters,
+			paymentMethod:
+				filters.paymentMethod === value
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["paymentMethod"]>),
+		});
+	};
+
+	const setPaymentMethod = (value: string) => {
+		onChange({
+			...filters,
+			paymentMethod:
+				value === "all"
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["paymentMethod"]>),
+		});
+	};
+
+	if (variant === "toolbar") {
+		return (
+			<Card className="hidden md:flex lg:hidden border border-border/70 shadow-none py-4">
+				<CardContent className="px-4">
+					<div className="grid grid-cols-1 md:grid-cols-2 gap-3 xl:grid-cols-4">
+						<div className="space-y-1">
+							<p className="text-caption text-muted-foreground font-semibold uppercase tracking-wide">
+								{t("filters.categoryLabel")}
+							</p>
+							<Select
+								value={filters.category ?? "all"}
+								onValueChange={setCategory}
+							>
+								<SelectTrigger className="h-10">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{categoryOptions.map((option) => (
+										<SelectItem
+											key={option.value}
+											value={option.value}
+										>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="space-y-1">
+							<p className="text-caption text-muted-foreground font-semibold uppercase tracking-wide">
+								{t("filters.statusLabel")}
+							</p>
+							<Select
+								value={filters.status ?? "all"}
+								onValueChange={setStatus}
+							>
+								<SelectTrigger className="h-10">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{statusOptions.map((option) => (
+										<SelectItem
+											key={option.value}
+											value={option.value}
+										>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="space-y-1">
+							<p className="text-caption text-muted-foreground font-semibold uppercase tracking-wide">
+								{t("filters.paymentMethodLabel")}
+							</p>
+							<Select
+								value={filters.paymentMethod ?? "all"}
+								onValueChange={setPaymentMethod}
+							>
+								<SelectTrigger className="h-10">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{paymentMethodOptions.map((option) => (
+										<SelectItem
+											key={option.value}
+											value={option.value}
+										>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="flex items-end justify-end gap-2">
+							<Button
+								type="button"
+								variant="ghost"
+								onClick={onClear}
+							>
+								{t("filters.clear", "Clear")}
+							</Button>
+							<Button
+								type="button"
+								onClick={onApply}
+							>
+								{t("filters.apply", "Apply")}
+							</Button>
+						</div>
+					</div>
+
+					<p className="mt-2 text-sm text-muted-foreground">
+						{activeFilterCount > 0
+							? t("filters.count", {
+									count: activeFilterCount,
+									defaultValue: "{{count}} selected",
+								})
+							: t("filters.noSelection", "No filters selected")}
+					</p>
+				</CardContent>
+			</Card>
+		);
+	}
+
+	return (
+		<Card className="hidden lg:flex border border-border/70 shadow-none py-4 bg-card">
+			<CardContent className="px-4 space-y-5">
+				<div>
+					<h3 className="text-2xl font-semibold tracking-tight">
+						{t("filters.title", "Filters")}
+					</h3>
+					<p className="mt-1 text-xs uppercase tracking-[0.18em] text-muted-foreground">
+						{t("filters.refine", "Refine expenses")}
+					</p>
+				</div>
+
+				<div className="space-y-2">
+					<p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+						{t("filters.categoryLabel")}
+					</p>
+					<Select
+						value={filters.category ?? "all"}
+						onValueChange={setCategory}
+					>
+						<SelectTrigger className="h-10 rounded-xl bg-muted/50 border-transparent px-3">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{categoryOptions.map((option) => (
+								<SelectItem
+									key={option.value}
+									value={option.value}
+								>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="space-y-2">
+					<p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+						{t("filters.statusLabel")}
+					</p>
+					<div className="grid grid-cols-2 gap-2">
+						{statusOptions.slice(1).map((option) => {
+							const isSelected = filters.status === option.value;
+
+							return (
+								<Button
+									key={option.value}
+									type="button"
+									variant="outline"
+									onClick={() => toggleStatus(option.value)}
+									className={cn(
+										"h-9 rounded-full justify-start px-3 text-xs",
+										isSelected
+											? "bg-primary text-primary-foreground border-primary hover:bg-primary/90"
+											: "bg-muted/50 border-transparent text-foreground hover:bg-muted",
+									)}
+								>
+									{isSelected && <Check className="h-3.5 w-3.5 mr-1.5" />}
+									<span className="truncate">{option.label}</span>
+								</Button>
+							);
+						})}
+					</div>
+				</div>
+
+				<div className="space-y-2">
+					<p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+						{t("filters.paymentMethodLabel")}
+					</p>
+					<div className="grid grid-cols-2 gap-2">
+						{paymentMethodOptions.slice(1).map((option) => {
+							const isSelected = filters.paymentMethod === option.value;
+
+							return (
+								<Button
+									key={option.value}
+									type="button"
+									variant="outline"
+									onClick={() => togglePaymentMethod(option.value)}
+									className={cn(
+										"h-9 rounded-full justify-start px-3 text-xs",
+										isSelected
+											? "bg-primary text-primary-foreground border-primary hover:bg-primary/90"
+											: "bg-muted/50 border-transparent text-foreground hover:bg-muted",
+									)}
+								>
+									{isSelected && <Check className="h-3.5 w-3.5 mr-1.5" />}
+									<span className="truncate">{option.label}</span>
+								</Button>
+							);
+						})}
+					</div>
+				</div>
+
+				<div className="pt-3 border-t">
+					<Button
+						type="button"
+						onClick={onApply}
+						className="w-full rounded-full"
+					>
+						{t("filters.apply", "Apply Filters")}
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={onClear}
+						className="w-full mt-1 uppercase tracking-[0.12em] text-[11px] text-muted-foreground"
+					>
+						{t("filters.clear", "Clear filters")}
+					</Button>
+					<p className="mt-2 text-xs text-muted-foreground text-center">
+						{activeFilterCount > 0
+							? t("filters.count", {
+									count: activeFilterCount,
+									defaultValue: "{{count}} selected",
+								})
+							: t("filters.noSelection", "No filters selected")}
+					</p>
+				</div>
+			</CardContent>
+		</Card>
+	);
+};

--- a/src/features/expense/components/expense-filter-sheet.tsx
+++ b/src/features/expense/components/expense-filter-sheet.tsx
@@ -1,0 +1,252 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+} from "@/components/ui/sheet";
+import {
+	expenseCategories,
+	expenseStatuses,
+	paymentMethods,
+	type IExpenseListFilters,
+} from "@/features/expense/types/expense-types";
+import {
+	expenseCategoryLabelKeys,
+	expenseStatusLabelKeys,
+	paymentMethodLabelKeys,
+} from "./expense-labels";
+import { Check } from "lucide-react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+interface ExpenseFilterSheetProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	filters: Partial<IExpenseListFilters>;
+	onChange: (filters: Partial<IExpenseListFilters>) => void;
+	onApply: () => void;
+}
+
+export const ExpenseFilterSheet = ({
+	open,
+	onOpenChange,
+	filters,
+	onChange,
+	onApply,
+}: ExpenseFilterSheetProps) => {
+	const { t } = useTranslation("expenses");
+
+	const categoryOptions = useMemo(
+		() => [
+			{ label: t("filters.allCategories"), value: "all" },
+			...expenseCategories.map((category) => ({
+				label: t(expenseCategoryLabelKeys[category] as never),
+				value: category,
+			})),
+		],
+		[t],
+	);
+
+	const statusOptions = useMemo(
+		() => [
+			...expenseStatuses.map((status) => ({
+				label: t(expenseStatusLabelKeys[status] as never),
+				value: status,
+			})),
+		],
+		[t],
+	);
+
+	const paymentMethodOptions = useMemo(
+		() => [
+			...paymentMethods.map((method) => ({
+				label: t(paymentMethodLabelKeys[method] as never),
+				value: method,
+			})),
+		],
+		[t],
+	);
+
+	const handleCategoryChange = (value: string) => {
+		onChange({
+			...filters,
+			category:
+				value === "all"
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["category"]>),
+		});
+	};
+
+	const handleStatusChange = (value: string) => {
+		onChange({
+			...filters,
+			status:
+				filters.status === value
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["status"]>),
+		});
+	};
+
+	const handlePaymentMethodChange = (value: string) => {
+		onChange({
+			...filters,
+			paymentMethod:
+				filters.paymentMethod === value
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["paymentMethod"]>),
+		});
+	};
+
+	const handleClearFilters = () => {
+		onChange({});
+	};
+
+	const activeFilterCount = Object.values(filters).filter(
+		(v) => v !== undefined,
+	).length;
+
+	const activeFiltersLabel =
+		activeFilterCount === 1
+			? t("filters.activeSingle", "active filter")
+			: t("filters.activePlural", "active filters");
+
+	return (
+		<Sheet
+			open={open}
+			onOpenChange={onOpenChange}
+		>
+			<SheetContent
+				side="bottom"
+				className="rounded-t-3xl max-h-[86vh] flex flex-col p-5"
+			>
+				<SheetHeader className="pb-2">
+					<SheetTitle className="text-3xl font-semibold tracking-tight">
+						{t("filters.title", "Filters")}
+					</SheetTitle>
+					{activeFilterCount > 0 && (
+						<SheetDescription className="text-sm">
+							{`${activeFilterCount} ${activeFiltersLabel}`}
+						</SheetDescription>
+					)}
+				</SheetHeader>
+
+				<div className="flex-1 overflow-y-auto space-y-6 py-2">
+					{/* Category Filter */}
+					<div className="space-y-2">
+						<label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+							{t("filters.categoryLabel")}
+						</label>
+						<Select
+							value={filters.category ?? "all"}
+							onValueChange={handleCategoryChange}
+						>
+							<SelectTrigger className="h-12 rounded-2xl bg-muted/60 border-transparent px-4 text-base">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{categoryOptions.map((option) => (
+									<SelectItem
+										key={option.value}
+										value={option.value}
+									>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					{/* Status Filter */}
+					<div className="space-y-2">
+						<label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+							{t("filters.statusLabel")}
+						</label>
+						<div className="grid grid-cols-2 gap-2">
+							{statusOptions.map((option) => {
+								const isSelected = filters.status === option.value;
+
+								return (
+									<Button
+										key={option.value}
+										type="button"
+										variant="outline"
+										onClick={() => handleStatusChange(option.value)}
+										className={cn(
+											"h-11 rounded-full justify-start px-4 text-sm",
+											isSelected
+												? "bg-primary text-primary-foreground border-primary hover:bg-primary/90"
+												: "bg-muted/60 border-transparent text-foreground hover:bg-muted",
+										)}
+									>
+										{isSelected && <Check className="h-4 w-4 mr-2" />}
+										<span className="truncate">{option.label}</span>
+									</Button>
+								);
+							})}
+						</div>
+					</div>
+
+					{/* Payment Method Filter */}
+					<div className="space-y-2">
+						<label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+							{t("filters.paymentMethodLabel")}
+						</label>
+						<div className="grid grid-cols-2 gap-2">
+							{paymentMethodOptions.map((option) => {
+								const isSelected = filters.paymentMethod === option.value;
+
+								return (
+									<Button
+										key={option.value}
+										type="button"
+										variant="outline"
+										onClick={() => handlePaymentMethodChange(option.value)}
+										className={cn(
+											"h-11 rounded-full justify-start px-4 text-sm",
+											isSelected
+												? "bg-primary text-primary-foreground border-primary hover:bg-primary/90"
+												: "bg-muted/60 border-transparent text-foreground hover:bg-muted",
+										)}
+									>
+										{isSelected && <Check className="h-4 w-4 mr-2" />}
+										<span className="truncate">{option.label}</span>
+									</Button>
+								);
+							})}
+						</div>
+					</div>
+				</div>
+
+				<SheetFooter className="border-t pt-4 mt-3">
+					<Button
+						type="button"
+						size="lg"
+						onClick={onApply}
+						className="w-full rounded-full"
+					>
+						{t("filters.apply", "Apply Filters")}
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						onClick={handleClearFilters}
+						className="w-full uppercase tracking-[0.16em] text-xs font-semibold text-muted-foreground"
+					>
+						{t("filters.clear", "Clear all")}
+					</Button>
+				</SheetFooter>
+			</SheetContent>
+		</Sheet>
+	);
+};

--- a/src/routes/_private/_privatelayout/farm/$farmId/expenses.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/expenses.tsx
@@ -2,7 +2,9 @@ import { PageHeader } from "@/components/common/page-header";
 import { ScrollablePageLayout } from "@/components/layout/scrollable-page-layout";
 import { Button } from "@/components/ui/button";
 import { useGetExpensesPage } from "@/features/expense/api/expense-queries";
-import { ExpenseFilterBar } from "@/features/expense/components/expense-filter-bar";
+import { ExpenseFilterSheet } from "@/features/expense/components/expense-filter-sheet";
+import { ExpenseFilterFAB } from "@/features/expense/components/expense-filter-fab";
+import { ExpenseFilterPanel } from "@/features/expense/components/expense-filter-panel";
 import { ExpenseFormModal } from "@/features/expense/components/expense-form-modal";
 import { ExpenseList } from "@/features/expense/components/expense-list";
 import { ExpenseListSkeleton } from "@/features/expense/components/expense-list-skeleton";
@@ -36,6 +38,10 @@ function RouteComponent() {
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useState(10);
 	const [filters, setFilters] = useState<Partial<IExpenseListFilters>>({});
+	const [draftFilters, setDraftFilters] = useState<
+		Partial<IExpenseListFilters>
+	>({});
+	const [filterSheetOpen, setFilterSheetOpen] = useState(false);
 	const {
 		data: pagedExpenses,
 		isPending,
@@ -54,125 +60,176 @@ function RouteComponent() {
 	const totalPages = pagedExpenses?.totalPages ?? 1;
 	const currencyCode = farmData?.currencyCode ?? "USD";
 
+	const handleFilterChange = (nextFilters: Partial<IExpenseListFilters>) => {
+		setFilters(nextFilters);
+		setPage(1);
+		scrollToTop();
+	};
+
+	const openFilterSheet = () => {
+		setDraftFilters(filters);
+		setFilterSheetOpen(true);
+	};
+
+	const applyDraftFilters = () => {
+		handleFilterChange(draftFilters);
+		setFilterSheetOpen(false);
+	};
+
+	const applyDesktopFilters = () => {
+		handleFilterChange(draftFilters);
+	};
+
+	const clearDesktopFilters = () => {
+		setDraftFilters({});
+		handleFilterChange({});
+	};
+
 	return (
-		<ScrollablePageLayout
-			className="max-w-5xl mx-auto pb-24"
-			header={
-				<div className="flex flex-col gap-4">
-					<PageHeader
-						title={t("page.title")}
-						description={t("page.description")}
-						action={
-							<ExpenseFormModal
-								farmId={farmId!}
-								filters={filters}
-							/>
-						}
-					/>
-					<ExpenseFilterBar
-						filters={filters}
-						onChange={(nextFilters) => {
-							setFilters(nextFilters);
-							setPage(1);
-							scrollToTop();
-						}}
-					/>
-				</div>
-			}
-		>
-			<div className="flex flex-col gap-4">
-				{!isPending && !isError && (
-					<ExpenseSummaryStrip
-						expenses={expenses}
-						currencyCode={currencyCode}
-					/>
-				)}
-
-				{isPending && <ExpenseListSkeleton />}
-
-				{isError && (
-					<div className="rounded-card border p-4 flex flex-col gap-2">
-						<p className="text-destructive text-sm">{error.message}</p>
-						<div>
-							<Button
-								variant="outline"
-								onClick={() => void refetch()}
-							>
-								{t("page.retry")}
-							</Button>
-						</div>
-					</div>
-				)}
-
-				{!isPending && !isError && expenses.length === 0 && (
-					<div className="rounded-card border p-8 text-center text-muted-foreground">
-						{t("page.empty")}
-					</div>
-				)}
-
-				{!isPending && !isError && expenses.length > 0 && (
+		<>
+			<ScrollablePageLayout
+				className="max-w-7xl mx-auto pb-24"
+				header={
 					<div className="space-y-3">
-						<ExpenseList
-							expenses={expenses}
-							farmId={farmId!}
-							filters={filters}
-							currencyCode={currencyCode}
+						<PageHeader
+							title={t("page.title")}
+							description={t("page.description")}
+							action={
+								<ExpenseFormModal
+									farmId={farmId!}
+									filters={filters}
+								/>
+							}
 						/>
-						<div className="flex flex-wrap items-center gap-2">
-							<label className="text-caption text-muted-foreground">
-								{t("page.perPage")}
-							</label>
-							<select
-								className="h-9 rounded-md border border-input bg-background px-2 text-sm"
-								value={pageSize}
-								onChange={(event) => {
-									setPageSize(Number(event.target.value));
-									setPage(1);
-									scrollToTop();
-								}}
-							>
-								{pageSizeOptions.map((option) => (
-									<option
-										key={option}
-										value={option}
-									>
-										{option}
-									</option>
-								))}
-							</select>
-							<Button
-								variant="outline"
-								onClick={() => {
-									setPage((previous) => Math.max(previous - 1, 1));
-									scrollToTop();
-								}}
-								disabled={page <= 1 || isFetching}
-							>
-								{t("page.previous")}
-							</Button>
-							<Button
-								variant="outline"
-								onClick={() => {
-									setPage((previous) => Math.min(previous + 1, totalPages));
-									scrollToTop();
-								}}
-								disabled={page >= totalPages || isFetching}
-							>
-								{t("page.next")}
-							</Button>
-							<span className="text-caption text-muted-foreground">
-								{t("page.pageLabel", { page, totalPages })}
-							</span>
-						</div>
-						<p className="text-caption text-muted-foreground">
-							{t("page.showingCount", {
-								visible: expenses.length,
-								total: totalExpenses,
-							})}
-						</p>
+						<ExpenseFilterPanel
+							variant="toolbar"
+							filters={draftFilters}
+							onChange={setDraftFilters}
+							onApply={applyDesktopFilters}
+							onClear={clearDesktopFilters}
+						/>
 					</div>
-				)}
-			</div>
-		</ScrollablePageLayout>
+				}
+			>
+				<div className="grid gap-4 lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-6">
+					<div className="hidden lg:block lg:sticky lg:top-24 lg:self-start">
+						<ExpenseFilterPanel
+							variant="sidebar"
+							filters={draftFilters}
+							onChange={setDraftFilters}
+							onApply={applyDesktopFilters}
+							onClear={clearDesktopFilters}
+						/>
+					</div>
+
+					<div className="flex flex-col gap-4">
+						{!isPending && !isError && (
+							<ExpenseSummaryStrip
+								expenses={expenses}
+								currencyCode={currencyCode}
+							/>
+						)}
+
+						{isPending && <ExpenseListSkeleton />}
+
+						{isError && (
+							<div className="rounded-card border p-4 flex flex-col gap-2">
+								<p className="text-destructive text-sm">{error.message}</p>
+								<div>
+									<Button
+										variant="outline"
+										onClick={() => void refetch()}
+									>
+										{t("page.retry")}
+									</Button>
+								</div>
+							</div>
+						)}
+
+						{!isPending && !isError && expenses.length === 0 && (
+							<div className="rounded-card border p-8 text-center text-muted-foreground">
+								{t("page.empty")}
+							</div>
+						)}
+
+						{!isPending && !isError && expenses.length > 0 && (
+							<div className="space-y-3">
+								<ExpenseList
+									expenses={expenses}
+									farmId={farmId!}
+									filters={filters}
+									currencyCode={currencyCode}
+								/>
+								<div className="flex flex-wrap items-center gap-2">
+									<label className="text-caption text-muted-foreground">
+										{t("page.perPage")}
+									</label>
+									<select
+										className="h-9 rounded-md border border-input bg-background px-2 text-sm"
+										value={pageSize}
+										onChange={(event) => {
+											setPageSize(Number(event.target.value));
+											setPage(1);
+											scrollToTop();
+										}}
+									>
+										{pageSizeOptions.map((option) => (
+											<option
+												key={option}
+												value={option}
+											>
+												{option}
+											</option>
+										))}
+									</select>
+									<Button
+										variant="outline"
+										onClick={() => {
+											setPage((previous) => Math.max(previous - 1, 1));
+											scrollToTop();
+										}}
+										disabled={page <= 1 || isFetching}
+									>
+										{t("page.previous")}
+									</Button>
+									<Button
+										variant="outline"
+										onClick={() => {
+											setPage((previous) => Math.min(previous + 1, totalPages));
+											scrollToTop();
+										}}
+										disabled={page >= totalPages || isFetching}
+									>
+										{t("page.next")}
+									</Button>
+									<span className="text-caption text-muted-foreground">
+										{t("page.pageLabel", { page, totalPages })}
+									</span>
+								</div>
+								<p className="text-caption text-muted-foreground">
+									{t("page.showingCount", {
+										visible: expenses.length,
+										total: totalExpenses,
+									})}
+								</p>
+							</div>
+						)}
+					</div>
+				</div>
+			</ScrollablePageLayout>
+
+			<ExpenseFilterSheet
+				open={filterSheetOpen}
+				onOpenChange={setFilterSheetOpen}
+				filters={draftFilters}
+				onChange={setDraftFilters}
+				onApply={applyDraftFilters}
+			/>
+
+			<ExpenseFilterFAB
+				filters={filters}
+				onOpen={openFilterSheet}
+			/>
+		</>
 	);
 }


### PR DESCRIPTION
## Summary
Implement a mobile-first expense filtering redesign with explicit draft/apply behavior and add email normalization safeguards in auth.

## What Changed
- Reworked expense filters to a responsive experience:
  - Mobile: bottom pill trigger plus bottom sheet.
  - Tablet: compact top filter toolbar.
  - Desktop: sticky left filter panel.
- Switched filtering from immediate updates to a draft-then-apply flow.
- Added active filter count feedback and improved filter UI states.
- Added auth email normalization before API requests:
  - login/signup payload emails now use `trim().toLowerCase()`.
- Updated login/signup email inputs for mobile behavior:
  - `type="email"`
  - `autoComplete="email"`
  - `autoCapitalize="none"`
  - `autoCorrect="off"`
  - `spellCheck={false}`

## Validation Performed
- `npm run build` passed.
- `npm run lint` failed due to missing local dependency `eslint-plugin-react-you-might-not-need-an-effect`.

## Risks / Notes
- Lint could not be fully validated locally until the missing ESLint plugin is available.
- UI behavior changed significantly across breakpoints; recommend manual UX smoke checks on mobile, tablet, and desktop before merge.
