### PR TITLE
feat(flock): add flock management pages and responsive workflows

### DIFF
--- a/src/features/flock/components/create-flock-modal.tsx
+++ b/src/features/flock/components/create-flock-modal.tsx
@@ -34,7 +34,10 @@ export const CreateFlockModal = ({
 	};
 
 	return (
-		<Dialog open={open} onOpenChange={handleOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={handleOpenChange}
+		>
 			{!isControlled && (
 				<DialogTrigger asChild>
 					<Button>
@@ -43,7 +46,7 @@ export const CreateFlockModal = ({
 					</Button>
 				</DialogTrigger>
 			)}
-			<DialogContent className="w-full max-h-[90vh] overflow-y-auto p-4 sm:max-w-lg">
+			<DialogContent className="w-[calc(100vw-2rem)] max-w-[42rem] min-w-[20rem] max-h-[90vh] overflow-y-auto p-4 sm:p-6">
 				<DialogTitle>{t("createModal.title")}</DialogTitle>
 				<DialogDescription>{t("createModal.description")}</DialogDescription>
 				<CreateFlockForm

--- a/src/features/flock/components/flock-card.tsx
+++ b/src/features/flock/components/flock-card.tsx
@@ -13,24 +13,36 @@ interface FlockCardProps {
 
 const getTranslationName = (
 	translations: Array<{ language: string; name: string }> | undefined,
+	preferredLanguage: string,
 ): string => {
 	if (!translations || translations.length === 0) {
 		return "-";
 	}
 
-	const preferredTranslation = translations.find(
-		(item) => item.language === "en" || item.language === "es",
-	);
+	const normalizedPreferredLanguage = preferredLanguage.toLowerCase();
+	const preferredTranslation =
+		translations.find(
+			(item) => item.language.toLowerCase() === normalizedPreferredLanguage,
+		) ??
+		translations.find((item) => item.language.toLowerCase() === "en") ??
+		translations.find((item) => item.language.toLowerCase() === "es");
 
 	return preferredTranslation?.name ?? translations[0].name;
 };
 
 export const FlockCard = ({ flock }: FlockCardProps) => {
-	const { t } = useTranslation("flocks");
+	const { t, i18n } = useTranslation("flocks");
 	const { farmId } = useParams({ strict: false });
+	const preferredLanguage = i18n.language.slice(0, 2) || "en";
 
-	const speciesName = getTranslationName(flock.species?.translations);
-	const breedName = getTranslationName(flock.breed?.translations);
+	const speciesName = getTranslationName(
+		flock.species?.translations,
+		preferredLanguage,
+	);
+	const breedName = getTranslationName(
+		flock.breed?.translations,
+		preferredLanguage,
+	);
 	const occupancyRatio = Math.max(
 		0,
 		Math.min(100, Math.round((flock.currentCount / flock.initialCount) * 100)),

--- a/src/features/flock/components/update-flock-count-modal.tsx
+++ b/src/features/flock/components/update-flock-count-modal.tsx
@@ -56,19 +56,23 @@ export const UpdateFlockCountModal = ({
 			return;
 		}
 
-		const response = await createFlockEvent({
-			flockId: flock.id,
-			farmId,
-			payload: {
-				eventType: deltaCount > 0 ? "addition" : "mortality",
-				count: Math.abs(deltaCount),
-				date: new Date().toISOString().slice(0, 10),
-				reason: t("countEditor.adjustmentReason"),
-			},
-		});
+		try {
+			const response = await createFlockEvent({
+				flockId: flock.id,
+				farmId,
+				payload: {
+					eventType: deltaCount > 0 ? "addition" : "mortality",
+					count: Math.abs(deltaCount),
+					date: new Date().toISOString().slice(0, 10),
+					reason: t("countEditor.adjustmentReason"),
+				},
+			});
 
-		if (response.status === "success") {
-			setIsEditing(false);
+			if (response.status === "success") {
+				setIsEditing(false);
+			}
+		} catch {
+			// Mutation onError already handles user feedback via toast.
 		}
 	};
 

--- a/src/routes/_private/_privatelayout/farm/$farmId/flocks.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/flocks.tsx
@@ -167,11 +167,11 @@ function RouteComponent() {
 							title={t("page.title")}
 							description={t("page.description")}
 							action={
-							<Button onClick={() => setIsCreateOpen(true)}>
-								<Plus className="h-4 w-4" />
-								{t("page.newButton")}
-							</Button>
-						}
+								<Button onClick={() => setIsCreateOpen(true)}>
+									<Plus className="h-4 w-4" />
+									{t("page.newButton")}
+								</Button>
+							}
 						/>
 					</div>
 					<div className="hidden items-center justify-between rounded-[24px] border border-border/70 bg-card px-5 py-4 shadow-sm md:flex">
@@ -186,12 +186,6 @@ function RouteComponent() {
 								</p>
 							</div>
 						</div>
-						<nav className="flex items-center gap-8 text-sm font-semibold text-muted-foreground">
-							<span className="text-foreground">{t("desktopNav.flocks")}</span>
-							<span>{t("desktopNav.reports")}</span>
-							<span>{t("desktopNav.health")}</span>
-							<span>{t("desktopNav.profile")}</span>
-						</nav>
 						<Button onClick={() => setIsCreateOpen(true)}>
 							<Plus className="h-4 w-4" />
 							{t("page.newButton")}
@@ -285,11 +279,11 @@ function RouteComponent() {
 					</>
 				)}
 			</div>
-		<CreateFlockModal
-			farmId={farmId!}
-			open={isCreateOpen}
-			onOpenChange={setIsCreateOpen}
-		/>
+			<CreateFlockModal
+				farmId={farmId!}
+				open={isCreateOpen}
+				onOpenChange={setIsCreateOpen}
+			/>
 		</ScrollablePageLayout>
 	);
 }

--- a/src/routes/_private/_privatelayout/farm/$farmId/flocks/$flockId.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/flocks/$flockId.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from "@/components/common/page-header";
 import { ScrollablePageLayout } from "@/components/layout/scrollable-page-layout";
+import { Button } from "@/components/ui/button";
 import {
 	useGetEggCollectionsPage,
 	useGetFlockById,
@@ -19,24 +20,46 @@ export const Route = createFileRoute(
 function RouteComponent() {
 	const { t } = useTranslation("flocks");
 	const { flockId } = useParams({ strict: false });
+	const getErrorMessage = (error: unknown, fallback: string): string => {
+		if (error instanceof Error && error.message) {
+			return error.message;
+		}
 
-	const { data: flock, isPending: isFlockLoading } = useGetFlockById({
+		return fallback;
+	};
+
+	const {
+		data: flock,
+		isPending: isFlockLoading,
+		isError: isFlockError,
+		error: flockError,
+		refetch: refetchFlock,
+	} = useGetFlockById({
 		flockId: flockId!,
 		include: "species.translations,breed.translations",
 	});
-	const { data: eventData, isPending: isEventsLoading } = useGetFlockEventsPage(
-		{
-			flockId: flockId!,
-			page: 1,
-			limit: 10,
-		},
-	);
-	const { data: eggCollectionData, isPending: isEggCollectionsLoading } =
-		useGetEggCollectionsPage({
-			flockId: flockId!,
-			page: 1,
-			limit: 10,
-		});
+	const {
+		data: eventData,
+		isPending: isEventsLoading,
+		isError: isEventsError,
+		error: eventsError,
+		refetch: refetchEvents,
+	} = useGetFlockEventsPage({
+		flockId: flockId!,
+		page: 1,
+		limit: 10,
+	});
+	const {
+		data: eggCollectionData,
+		isPending: isEggCollectionsLoading,
+		isError: isEggCollectionsError,
+		error: eggCollectionsError,
+		refetch: refetchEggCollections,
+	} = useGetEggCollectionsPage({
+		flockId: flockId!,
+		page: 1,
+		limit: 10,
+	});
 
 	return (
 		<ScrollablePageLayout
@@ -51,6 +74,20 @@ function RouteComponent() {
 			{isFlockLoading ? (
 				<div className="rounded-card border p-6 text-center text-muted-foreground">
 					{t("detail.loading")}
+				</div>
+			) : isFlockError ? (
+				<div className="rounded-card border p-4 flex flex-col gap-2">
+					<p className="text-destructive text-sm">
+						{getErrorMessage(flockError, t("detail.loading"))}
+					</p>
+					<div>
+						<Button
+							variant="outline"
+							onClick={() => void refetchFlock()}
+						>
+							{t("page.retry")}
+						</Button>
+					</div>
 				</div>
 			) : (
 				<div className="space-y-4">
@@ -79,6 +116,20 @@ function RouteComponent() {
 							<div className="rounded-card border p-6 text-center text-muted-foreground">
 								{t("detail.events.loading")}
 							</div>
+						) : isEventsError ? (
+							<div className="rounded-card border p-4 flex flex-col gap-2">
+								<p className="text-destructive text-sm">
+									{getErrorMessage(eventsError, t("detail.events.loading"))}
+								</p>
+								<div>
+									<Button
+										variant="outline"
+										onClick={() => void refetchEvents()}
+									>
+										{t("page.retry")}
+									</Button>
+								</div>
+							</div>
 						) : (
 							<FlockEventsList events={eventData?.items ?? []} />
 						)}
@@ -89,6 +140,23 @@ function RouteComponent() {
 						{isEggCollectionsLoading ? (
 							<div className="rounded-card border p-6 text-center text-muted-foreground">
 								{t("detail.eggCollections.loading")}
+							</div>
+						) : isEggCollectionsError ? (
+							<div className="rounded-card border p-4 flex flex-col gap-2">
+								<p className="text-destructive text-sm">
+									{getErrorMessage(
+										eggCollectionsError,
+										t("detail.eggCollections.loading"),
+									)}
+								</p>
+								<div>
+									<Button
+										variant="outline"
+										onClick={() => void refetchEggCollections()}
+									>
+										{t("page.retry")}
+									</Button>
+								</div>
 							</div>
 						) : (
 							<EggCollectionsList


### PR DESCRIPTION
## Summary
Add end-to-end flock management UI and data flows, including flock list/detail pages, create flow, count adjustment flow, filtering, and responsive layout refinements.

## What changed
- Added flock pages and route integration for list and detail views.
- Added flock API/query support for update-by-id, events, and paginated data usage.
- Implemented create flock modal/form and count adjustment editor with event creation.
- Added desktop/mobile flock list presentation components (cards, stats, filter panel, status badge).
- Improved modal responsiveness on tablet/desktop and removed unused desktop top nav row.
- Added detail-page error states with retry actions for flock, events, and egg collections.
- Added flock and bottom-tab-nav i18n resource updates (EN/ES).

## Validation performed
- npm run build: pass
- npm run lint: fail (missing eslint-plugin-react-you-might-not-need-an-effect in eslint config)

## Risks / notes
- Lint cannot run in current environment until the missing ESLint plugin is installed or removed from config.
- Build emits existing chunk-size warnings; no new build-breaking issues observed.
