### PR TITLE
fix(animal): stabilize modal sizing on tablet and desktop

### DIFF
--- a/src/features/animal/components/delete-animal-modal/delete-animal-modal.tsx
+++ b/src/features/animal/components/delete-animal-modal/delete-animal-modal.tsx
@@ -35,7 +35,7 @@ export const DeleteAnimalModal = ({
 			filters: {
 				sex,
 				speciesId,
-			}
+			},
 		});
 		if (response.status === "success") setOpen(false);
 	};
@@ -50,7 +50,7 @@ export const DeleteAnimalModal = ({
 					<Trash2 />
 				</Button>
 			</DialogTrigger>
-			<DialogContent className="max-w-70">
+			<DialogContent className="w-[calc(100vw-2rem)] max-w-[30rem] min-w-[20rem] p-4 sm:p-6">
 				<DialogTitle>
 					{t("deleteTitle1")}
 					{animal.name} {animal.tagNumber}

--- a/src/features/animal/components/edit-animal-modal/edit-animal-modal.tsx
+++ b/src/features/animal/components/edit-animal-modal/edit-animal-modal.tsx
@@ -37,7 +37,7 @@ export const EditAnimalModal = ({ animal, trigger }: EditAnimalModalProps) => {
 					</Button>
 				)}
 			</DialogTrigger>
-			<DialogContent className="max-h-[90vh] overflow-y-auto p-4">
+			<DialogContent className="w-[calc(100vw-2rem)] max-w-[36rem] min-w-[20rem] max-h-[90vh] overflow-y-auto p-4 sm:max-w-[36rem] sm:p-6">
 				<DialogTitle>{t("editTitle")}</DialogTitle>
 				<DialogDescription>{t("editDescription")}</DialogDescription>
 				<EditAnimalForm

--- a/src/features/animal/components/new-animal-modal/new-animal-modal.tsx
+++ b/src/features/animal/components/new-animal-modal/new-animal-modal.tsx
@@ -47,7 +47,7 @@ export const NewAnimalModal = ({
 					</Button>
 				</DialogTrigger>
 			)}
-			<DialogContent className="max-h-[90vh] overflow-y-auto p-4">
+			<DialogContent className="w-[calc(100vw-2rem)] max-w-[42rem] min-w-[20rem] max-h-[90vh] overflow-y-auto p-4 sm:p-6">
 				<DialogTitle>{t("addAnimalTitle")}</DialogTitle>
 				<DialogDescription>{t("addAnimalDescription")}</DialogDescription>
 				<RadioGroup


### PR DESCRIPTION
## Summary
Fixes animal creation, edit, and delete modal sizing issues that caused collapsed or inconsistent widths on tablet and larger screens.

## What changed
- Updated new animal modal dialog width constraints for stable tablet and desktop rendering.
- Updated edit animal modal with explicit responsive max width override to avoid inherited narrow breakpoint limits.
- Updated delete animal modal width classes to match responsive dialog sizing behavior.

## Validation performed
- npm run build (pass)
- npm run lint (fails in environment due to missing eslint-plugin-react-you-might-not-need-an-effect dependency)

## Risks and notes
- Lint cannot complete until the missing ESLint plugin dependency is installed or the config is updated.
- Visual behavior was tuned to moderate modal widths to avoid both narrow collapse and over-wide layouts.
