### PR TITLE
fix(animal): correct edit endpoint and tighten PR prompt rules

### DIFF
--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -37,6 +37,7 @@ User intent: ${input:Optional PR intent/title hint — prefix with 'draft' and/o
    - Summary
    - What changed
    - Validation performed
+   - Validation format rule: list only the validation type and status (Passed/Failed); do not paste command output, logs, stack traces, or code snippets.
    - Risks/notes
 9. Create the PR using resolved head/base branches:
    - Default: ready PR

--- a/src/features/animal/api/animal-api.ts
+++ b/src/features/animal/api/animal-api.ts
@@ -72,16 +72,14 @@ export const getAnimalById = ({
 
 export const editAnimalById = ({
 	payload,
-	farmId,
 	animalId,
 }: {
 	payload: IEditAnimalPayload;
-	farmId: string;
 	animalId: string;
 }) =>
 	axiosHelper<IResponse<IAnimal>>({
 		method: "put",
-		url: `/farms/${farmId}/animals/${animalId}`,
+		url: `/animals/${animalId}`,
 		data: payload,
 	});
 

--- a/src/features/animal/api/animal-queries.ts
+++ b/src/features/animal/api/animal-queries.ts
@@ -409,14 +409,13 @@ export const useEditAnimalById = () => {
 	return useMutation({
 		mutationFn: ({
 			payload,
-			farmId,
 			animalId,
 		}: {
 			payload: IEditAnimalPayload;
 			farmId: string;
 			animalId: string;
 			filters?: Partial<IAnimalListFilters>;
-		}) => editAnimalById({ payload, farmId, animalId }),
+		}) => editAnimalById({ payload, animalId }),
 		onError: (error) => {
 			toast.error(error.message);
 		},


### PR DESCRIPTION
## Summary
Fixes the animal edit request returning 404, and updates the PR prompt to enforce a concise validation format in PR descriptions.

## What Changed
- `src/features/animal/api/animal-api.ts` — Updated `editAnimalById` to use `/animals/:animalId` instead of the farm-scoped path `/farms/:farmId/animals/:animalId`.
- `src/features/animal/api/animal-queries.ts` — Removed `farmId` from the `editAnimalById` call site in the mutation fn; kept it where needed for cache invalidation.
- `.github/prompts/pr.prompt.md` — Added rule to keep Validation Performed to type + status only; no pasted logs or output.

## Validation Performed
- Build: Passed
- Lint: Failed (missing ESLint dependency in environment, pre-existing)

## Risks / Notes
- Low risk: animal API change is isolated to the edit mutation URL construction.
- Prompt change is docs-only with no runtime impact.
