### PR TITLE
feat: weather dashboard card and flock egg collection flow

### DIFF
--- a/src/features/flock/api/flock-api.ts
+++ b/src/features/flock/api/flock-api.ts
@@ -6,12 +6,14 @@ export const deleteFlockById = ({ flockId }: { flockId: string }) =>
 import { axiosHelper } from "@/lib/axios/axios-helper";
 import type { IResponse } from "@/lib/axios";
 import type {
+	ICreateEggCollectionPayload,
 	ICreateFlockPayload,
 	ICreateFlockEventPayload,
 	IEggCollection,
 	IFlock,
 	IFlockEvent,
 	IFlockListFilters,
+	IUpdateEggCollectionPayload,
 	IUpdateFlockPayload,
 } from "@/features/flock/types/flock-types";
 import i18next from "i18next";
@@ -174,4 +176,44 @@ export const getEggCollections = ({
 			page: String(page),
 			limit: String(limit),
 		},
+	});
+
+export const createEggCollection = ({
+	flockId,
+	payload,
+}: {
+	flockId: string;
+	payload: ICreateEggCollectionPayload;
+}) =>
+	axiosHelper<IResponse<IEggCollection>>({
+		method: "post",
+		url: `/flocks/${flockId}/egg-collections`,
+		data: payload,
+	});
+
+export const updateEggCollection = ({
+	flockId,
+	collectionId,
+	payload,
+}: {
+	flockId: string;
+	collectionId: string;
+	payload: IUpdateEggCollectionPayload;
+}) =>
+	axiosHelper<IResponse<IEggCollection>>({
+		method: "put",
+		url: `/flocks/${flockId}/egg-collections/${collectionId}`,
+		data: payload,
+	});
+
+export const deleteEggCollection = ({
+	flockId,
+	collectionId,
+}: {
+	flockId: string;
+	collectionId: string;
+}) =>
+	axiosHelper<IResponse<{ message: string }>>({
+		method: "delete",
+		url: `/flocks/${flockId}/egg-collections/${collectionId}`,
 	});

--- a/src/features/flock/api/flock-queries.ts
+++ b/src/features/flock/api/flock-queries.ts
@@ -20,18 +20,23 @@ export const useDeleteFlockById = () => {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { keepPreviousData } from "@tanstack/react-query";
 import {
+	createEggCollection,
 	createFlockEvent,
 	createFlock,
+	deleteEggCollection,
 	getEggCollections,
 	getFlockById,
 	getFlockEvents,
 	getFlocks,
+	updateEggCollection,
 	updateFlockById,
 } from "@/features/flock/api/flock-api";
 import type {
+	ICreateEggCollectionPayload,
 	ICreateFlockPayload,
 	ICreateFlockEventPayload,
 	IFlockListFilters,
+	IUpdateEggCollectionPayload,
 	IUpdateFlockPayload,
 } from "@/features/flock/types/flock-types";
 import i18next from "i18next";
@@ -262,3 +267,77 @@ export const useGetEggCollectionsPage = ({
 		enabled: !!flockId,
 		placeholderData: keepPreviousData,
 	});
+
+export const useCreateEggCollection = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			flockId,
+			payload,
+		}: {
+			flockId: string;
+			farmId: string;
+			payload: ICreateEggCollectionPayload;
+		}) => createEggCollection({ flockId, payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: (_, { flockId }) => {
+			toast.success(i18next.t("flocks:detail.eggCollections.recordSuccess"));
+			void queryClient.invalidateQueries({
+				queryKey: [...flockQueryKeys.all, "eggCollections", flockId],
+			});
+		},
+	});
+};
+
+export const useUpdateEggCollection = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			flockId,
+			collectionId,
+			payload,
+		}: {
+			flockId: string;
+			farmId: string;
+			collectionId: string;
+			payload: IUpdateEggCollectionPayload;
+		}) => updateEggCollection({ flockId, collectionId, payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: (_, { flockId }) => {
+			toast.success(i18next.t("flocks:detail.eggCollections.updateSuccess"));
+			void queryClient.invalidateQueries({
+				queryKey: [...flockQueryKeys.all, "eggCollections", flockId],
+			});
+		},
+	});
+};
+
+export const useDeleteEggCollection = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			flockId,
+			collectionId,
+		}: {
+			flockId: string;
+			farmId: string;
+			collectionId: string;
+		}) => deleteEggCollection({ flockId, collectionId }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: (_, { flockId }) => {
+			toast.success(i18next.t("flocks:detail.eggCollections.deleteSuccess"));
+			void queryClient.invalidateQueries({
+				queryKey: [...flockQueryKeys.all, "eggCollections", flockId],
+			});
+		},
+	});
+};

--- a/src/features/flock/components/delete-egg-collection-dialog.tsx
+++ b/src/features/flock/components/delete-egg-collection-dialog.tsx
@@ -1,0 +1,77 @@
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { useDeleteEggCollection } from "@/features/flock/api/flock-queries";
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface DeleteEggCollectionDialogProps {
+	flockId: string;
+	farmId: string;
+	collectionId: string;
+}
+
+export const DeleteEggCollectionDialog = ({
+	flockId,
+	farmId,
+	collectionId,
+}: DeleteEggCollectionDialogProps) => {
+	const [open, setOpen] = useState(false);
+	const { t } = useTranslation("flocks");
+	const { mutateAsync: deleteCollection, isPending } = useDeleteEggCollection();
+
+	const handleConfirm = async () => {
+		const response = await deleteCollection({ flockId, farmId, collectionId });
+		if (response.status === "success") setOpen(false);
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={setOpen}
+		>
+			<DialogTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8 text-destructive hover:text-destructive"
+				>
+					<Trash2 className="h-4 w-4" />
+					<span className="sr-only">{t("detail.eggCollections.delete")}</span>
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="max-w-sm">
+				<DialogTitle>
+					{t("detail.eggCollections.deleteDialog.title")}
+				</DialogTitle>
+				<DialogDescription>
+					{t("detail.eggCollections.deleteDialog.description")}
+				</DialogDescription>
+				<div className="flex justify-end gap-2">
+					<Button
+						variant="outline"
+						onClick={() => setOpen(false)}
+						disabled={isPending}
+					>
+						{t("detail.eggCollections.deleteDialog.cancel")}
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={() => void handleConfirm()}
+						disabled={isPending}
+					>
+						{isPending
+							? t("common.deleting")
+							: t("detail.eggCollections.deleteDialog.confirm")}
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/src/features/flock/components/egg-collections-list.tsx
+++ b/src/features/flock/components/egg-collections-list.tsx
@@ -1,12 +1,61 @@
-import type { IEggCollection } from "@/features/flock/types/flock-types";
+import { DeleteEggCollectionDialog } from "@/features/flock/components/delete-egg-collection-dialog";
+import { RecordEggCollectionModal } from "@/features/flock/components/record-egg-collection-modal";
+import type {
+	IEggCollection,
+	IFlockEvent,
+} from "@/features/flock/types/flock-types";
 import { useTranslation } from "react-i18next";
 
 interface EggCollectionsListProps {
 	eggCollections: IEggCollection[];
+	flockId: string;
+	farmId: string;
+	flockInitialCount: number;
+	flockEventsForHistory: IFlockEvent[];
 }
+
+const getEventDelta = (event: IFlockEvent): number => {
+	switch (event.eventType) {
+		case "addition":
+			return event.count;
+		case "mortality":
+		case "sale":
+		case "cull":
+		case "transfer":
+			return -event.count;
+		default:
+			return 0;
+	}
+};
+
+const getFlockCountAtDate = ({
+	initialCount,
+	events,
+	date,
+}: {
+	initialCount: number;
+	events: IFlockEvent[];
+	date: string;
+}): number => {
+	const normalizedTargetDate = date.slice(0, 10);
+
+	const delta = events.reduce((sum, event) => {
+		if (event.date.slice(0, 10) > normalizedTargetDate) {
+			return sum;
+		}
+
+		return sum + getEventDelta(event);
+	}, 0);
+
+	return Math.max(0, initialCount + delta);
+};
 
 export const EggCollectionsList = ({
 	eggCollections,
+	flockId,
+	farmId,
+	flockInitialCount,
+	flockEventsForHistory,
 }: EggCollectionsListProps) => {
 	const { t } = useTranslation("flocks");
 
@@ -20,28 +69,53 @@ export const EggCollectionsList = ({
 
 	return (
 		<div className="space-y-2">
-			{eggCollections.map((eggCollection) => (
-				<div
-					key={eggCollection.id}
-					className="rounded-card border p-3"
-				>
-					<div className="flex items-center justify-between gap-2">
-						<p className="font-medium">{eggCollection.date}</p>
-						<p className="text-sm text-muted-foreground">
-							{t("detail.eggCollections.layRate", {
-								layRate: eggCollection.layRate.toFixed(2),
+			{eggCollections.map((eggCollection) => {
+				const flockCountAtCollection = getFlockCountAtDate({
+					initialCount: flockInitialCount,
+					events: flockEventsForHistory,
+					date: eggCollection.date,
+				});
+				const stableLayRate =
+					flockCountAtCollection > 0
+						? (eggCollection.totalEggs / flockCountAtCollection) * 100
+						: 0;
+
+				return (
+					<div
+						key={eggCollection.id}
+						className="rounded-card border p-3"
+					>
+						<div className="flex items-center justify-between gap-2">
+							<p className="font-medium">{eggCollection.date}</p>
+							<div className="flex items-center gap-1">
+								<p className="text-sm text-muted-foreground">
+									{t("detail.eggCollections.layRate", {
+										layRate: stableLayRate.toFixed(2),
+									})}
+								</p>
+								<RecordEggCollectionModal
+									mode="edit"
+									flockId={flockId}
+									farmId={farmId}
+									collection={eggCollection}
+								/>
+								<DeleteEggCollectionDialog
+									flockId={flockId}
+									farmId={farmId}
+									collectionId={eggCollection.id}
+								/>
+							</div>
+						</div>
+						<p className="text-sm">
+							{t("detail.eggCollections.totals", {
+								totalEggs: eggCollection.totalEggs,
+								usableEggs: eggCollection.usableEggs,
+								brokenEggs: eggCollection.brokenEggs,
 							})}
 						</p>
 					</div>
-					<p className="text-sm">
-						{t("detail.eggCollections.totals", {
-							totalEggs: eggCollection.totalEggs,
-							usableEggs: eggCollection.usableEggs,
-							brokenEggs: eggCollection.brokenEggs,
-						})}
-					</p>
-				</div>
-			))}
+				);
+			})}
 		</div>
 	);
 };

--- a/src/features/flock/components/flock-card.tsx
+++ b/src/features/flock/components/flock-card.tsx
@@ -13,7 +13,7 @@ import type { IFlock } from "@/features/flock/types/flock-types";
 import { FlockStatusBadge } from "@/features/flock/components/flock-status-badge";
 import { UpdateFlockCountModal } from "@/features/flock/components/update-flock-count-modal";
 import { useTranslation } from "react-i18next";
-import { Link, useParams } from "@tanstack/react-router";
+import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { EllipsisVertical, Trash2 } from "lucide-react";
 
 interface FlockCardProps {
@@ -42,6 +42,7 @@ const getTranslationName = (
 export const FlockCard = ({ flock }: FlockCardProps) => {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const { mutate: deleteFlock, isPending: isDeleting } = useDeleteFlockById();
+	const navigate = useNavigate();
 	const handleDelete = () => {
 		deleteFlock(
 			{ flockId: flock.id },
@@ -64,6 +65,15 @@ export const FlockCard = ({ flock }: FlockCardProps) => {
 		0,
 		Math.min(100, Math.round((flock.currentCount / flock.initialCount) * 100)),
 	);
+
+	const goToDetail = () => {
+		if (!farmId) return;
+
+		void navigate({
+			to: "/farm/$farmId/flocks/$flockId",
+			params: { farmId, flockId: flock.id },
+		});
+	};
 
 	return (
 		<>
@@ -94,7 +104,18 @@ export const FlockCard = ({ flock }: FlockCardProps) => {
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
-			<Card className="gap-0 rounded-[24px] border border-border/70 py-4 shadow-md md:hidden">
+			<Card
+				className="gap-0 rounded-[24px] border border-border/70 py-4 shadow-md md:hidden cursor-pointer"
+				role="link"
+				tabIndex={0}
+				onClick={goToDetail}
+				onKeyDown={(event) => {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						goToDetail();
+					}
+				}}
+			>
 				<CardHeader className="px-4 py-0">
 					<div className="flex items-start justify-between gap-3">
 						<div>
@@ -105,7 +126,10 @@ export const FlockCard = ({ flock }: FlockCardProps) => {
 								variant="destructive"
 								size="icon"
 								className="ml-2"
-								onClick={() => setDeleteDialogOpen(true)}
+								onClick={(event) => {
+									event.stopPropagation();
+									setDeleteDialogOpen(true);
+								}}
 								aria-label={t("deleteDialog.ariaLabel")}
 							>
 								<Trash2 className="w-5 h-5" />
@@ -169,7 +193,18 @@ export const FlockCard = ({ flock }: FlockCardProps) => {
 				</CardContent>
 			</Card>
 
-			<Card className="hidden gap-0 rounded-[24px] border border-border/20 py-5 shadow-[0px_12px_32px_rgba(28,28,24,0.06)] transition-transform duration-300 hover:-translate-y-1 md:flex">
+			<Card
+				className="hidden gap-0 rounded-[24px] border border-border/20 py-5 shadow-[0px_12px_32px_rgba(28,28,24,0.06)] transition-transform duration-300 hover:-translate-y-1 md:flex cursor-pointer"
+				role="link"
+				tabIndex={0}
+				onClick={goToDetail}
+				onKeyDown={(event) => {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						goToDetail();
+					}
+				}}
+			>
 				<CardHeader className="px-5 py-0">
 					<div className="flex items-start justify-between gap-3">
 						<div className="space-y-2">
@@ -182,7 +217,10 @@ export const FlockCard = ({ flock }: FlockCardProps) => {
 									variant="destructive"
 									size="icon"
 									className="ml-2"
-									onClick={() => setDeleteDialogOpen(true)}
+									onClick={(event) => {
+										event.stopPropagation();
+										setDeleteDialogOpen(true);
+									}}
 									aria-label={t("deleteDialog.ariaLabel")}
 								>
 									<Trash2 className="w-5 h-5" />
@@ -196,6 +234,7 @@ export const FlockCard = ({ flock }: FlockCardProps) => {
 							variant="ghost"
 							size="icon"
 							className="h-9 w-9 rounded-xl text-muted-foreground"
+							onClick={(event) => event.stopPropagation()}
 							asChild
 						>
 							<Link

--- a/src/features/flock/components/record-egg-collection-form.tsx
+++ b/src/features/flock/components/record-egg-collection-form.tsx
@@ -1,0 +1,212 @@
+import { Button } from "@/components/ui/button";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	useCreateEggCollection,
+	useUpdateEggCollection,
+} from "@/features/flock/api/flock-queries";
+import type { IEggCollection } from "@/features/flock/types/flock-types";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+
+const formSchema = z.object({
+	date: z.string().optional(),
+	totalEggs: z.coerce.number().int().min(0),
+	brokenEggs: z.coerce.number().int().min(0),
+	notes: z.string().max(500).optional(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface BaseProps {
+	flockId: string;
+	farmId: string;
+	onClose: () => void;
+}
+
+type RecordEggCollectionFormProps =
+	| (BaseProps & { mode: "create" })
+	| (BaseProps & { mode: "edit"; collection: IEggCollection });
+
+export const RecordEggCollectionForm = (
+	props: RecordEggCollectionFormProps,
+) => {
+	const { flockId, farmId, onClose } = props;
+	const { t } = useTranslation("flocks");
+	const { mutateAsync: createCollection, isPending: isCreating } =
+		useCreateEggCollection();
+	const { mutateAsync: updateCollection, isPending: isUpdating } =
+		useUpdateEggCollection();
+	const isPending = isCreating || isUpdating;
+
+	const defaultValues: FormValues =
+		props.mode === "edit"
+			? {
+					totalEggs: props.collection.totalEggs,
+					brokenEggs: props.collection.brokenEggs,
+					notes: props.collection.notes ?? "",
+				}
+			: {
+					date: new Date().toISOString().slice(0, 10),
+					totalEggs: 0,
+					brokenEggs: 0,
+					notes: "",
+				};
+
+	const form = useForm<FormValues>({
+		resolver: zodResolver(formSchema),
+		defaultValues,
+	});
+
+	const totalEggs = useWatch({ control: form.control, name: "totalEggs" });
+	const brokenEggs = useWatch({ control: form.control, name: "brokenEggs" });
+	const usableEggs = Math.max(
+		0,
+		(Number(totalEggs) || 0) - (Number(brokenEggs) || 0),
+	);
+
+	const onSubmit = async (values: FormValues) => {
+		if ((values.brokenEggs ?? 0) > values.totalEggs) {
+			form.setError("brokenEggs", {
+				message: t("detail.eggCollections.form.brokenExceedsTotal"),
+			});
+			return;
+		}
+
+		if (props.mode === "create") {
+			const response = await createCollection({
+				flockId,
+				farmId,
+				payload: {
+					date: values.date!,
+					totalEggs: values.totalEggs,
+					brokenEggs: values.brokenEggs,
+					notes: values.notes || undefined,
+				},
+			});
+			if (response.status === "success") onClose();
+		} else {
+			const response = await updateCollection({
+				flockId,
+				farmId,
+				collectionId: props.collection.id,
+				payload: {
+					totalEggs: values.totalEggs,
+					brokenEggs: values.brokenEggs,
+					notes: values.notes || undefined,
+				},
+			});
+			if (response.status === "success") onClose();
+		}
+	};
+
+	return (
+		<Form {...form}>
+			<form
+				className="flex flex-col gap-3"
+				onSubmit={form.handleSubmit(onSubmit)}
+			>
+				{props.mode === "create" && (
+					<FormField
+						control={form.control}
+						name="date"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>{t("detail.eggCollections.form.date")}</FormLabel>
+								<FormControl>
+									<Input
+										type="date"
+										required
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				)}
+				<FormField
+					control={form.control}
+					name="totalEggs"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>{t("detail.eggCollections.form.totalEggs")}</FormLabel>
+							<FormControl>
+								<Input
+									type="number"
+									min={0}
+									step={1}
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={form.control}
+					name="brokenEggs"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>
+								{t("detail.eggCollections.form.brokenEggs")}
+							</FormLabel>
+							<FormControl>
+								<Input
+									type="number"
+									min={0}
+									step={1}
+									{...field}
+								/>
+							</FormControl>
+							<p className="text-xs text-muted-foreground">
+								{t("detail.eggCollections.form.usableHelp", {
+									count: usableEggs,
+								})}
+							</p>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={form.control}
+					name="notes"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>{t("detail.eggCollections.form.notes")}</FormLabel>
+							<FormControl>
+								<Textarea
+									placeholder={t("detail.eggCollections.form.notesPlaceholder")}
+									{...field}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<Button
+					type="submit"
+					disabled={isPending}
+				>
+					{props.mode === "create"
+						? isPending
+							? t("detail.eggCollections.form.submitting")
+							: t("detail.eggCollections.form.submit")
+						: isPending
+							? t("detail.eggCollections.form.updating")
+							: t("detail.eggCollections.form.update")}
+				</Button>
+			</form>
+		</Form>
+	);
+};

--- a/src/features/flock/components/record-egg-collection-modal.tsx
+++ b/src/features/flock/components/record-egg-collection-modal.tsx
@@ -1,0 +1,80 @@
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { RecordEggCollectionForm } from "@/features/flock/components/record-egg-collection-form";
+import type { IEggCollection } from "@/features/flock/types/flock-types";
+import { Pencil, Plus } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface BaseProps {
+	flockId: string;
+	farmId: string;
+}
+
+type RecordEggCollectionModalProps =
+	| (BaseProps & { mode: "create" })
+	| (BaseProps & { mode: "edit"; collection: IEggCollection });
+
+export const RecordEggCollectionModal = (
+	props: RecordEggCollectionModalProps,
+) => {
+	const [open, setOpen] = useState(false);
+	const { t } = useTranslation("flocks");
+
+	const title =
+		props.mode === "create"
+			? t("detail.eggCollections.recordModal.title")
+			: t("detail.eggCollections.recordModal.editTitle");
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={setOpen}
+		>
+			<DialogTrigger asChild>
+				{props.mode === "create" ? (
+					<Button size="sm">
+						<Plus className="h-4 w-4" />
+						{t("detail.eggCollections.record")}
+					</Button>
+				) : (
+					<Button
+						variant="ghost"
+						size="icon"
+						className="h-8 w-8"
+					>
+						<Pencil className="h-4 w-4" />
+						<span className="sr-only">{t("detail.eggCollections.edit")}</span>
+					</Button>
+				)}
+			</DialogTrigger>
+			<DialogContent aria-describedby={undefined}>
+				<DialogHeader>
+					<DialogTitle>{title}</DialogTitle>
+				</DialogHeader>
+				{props.mode === "create" ? (
+					<RecordEggCollectionForm
+						mode="create"
+						flockId={props.flockId}
+						farmId={props.farmId}
+						onClose={() => setOpen(false)}
+					/>
+				) : (
+					<RecordEggCollectionForm
+						mode="edit"
+						flockId={props.flockId}
+						farmId={props.farmId}
+						collection={props.collection}
+						onClose={() => setOpen(false)}
+					/>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/src/features/flock/types/flock-types.ts
+++ b/src/features/flock/types/flock-types.ts
@@ -109,3 +109,16 @@ export interface IEggCollection {
 	createdAt: string;
 	updatedAt: string;
 }
+
+export interface ICreateEggCollectionPayload {
+	date: string;
+	totalEggs: number;
+	brokenEggs?: number;
+	notes?: string;
+}
+
+export interface IUpdateEggCollectionPayload {
+	totalEggs?: number;
+	brokenEggs?: number;
+	notes?: string;
+}

--- a/src/features/weather/components/dashboard-weather-card.tsx
+++ b/src/features/weather/components/dashboard-weather-card.tsx
@@ -1,0 +1,141 @@
+import { Cloud } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { WeatherData } from "@/features/weather/api/weather-api";
+import { weatherDescriptionKeyByCode } from "@/features/weather/weather-description-map";
+
+interface DashboardWeatherCardProps {
+	weatherData: WeatherData | undefined;
+	isGeoLoading: boolean;
+	geoError: string | null;
+	isWeatherLoading: boolean;
+	isWeatherError: boolean;
+	className?: string;
+}
+
+interface MetricProps {
+	label: string;
+	value: string;
+}
+
+function WeatherMetric({ label, value }: MetricProps) {
+	return (
+		<div className="rounded-md bg-muted/40 p-2.5 min-w-0">
+			<p className="text-[11px] leading-4 text-muted-foreground truncate">
+				{label}
+			</p>
+			<p className="text-sm font-semibold text-foreground wrap-break-word leading-5">
+				{value}
+			</p>
+		</div>
+	);
+}
+
+export function DashboardWeatherCard({
+	weatherData,
+	isGeoLoading,
+	geoError,
+	isWeatherLoading,
+	isWeatherError,
+	className,
+}: DashboardWeatherCardProps) {
+	const { t } = useTranslation("dashboard");
+
+	const isLoading = isGeoLoading || isWeatherLoading;
+	const hasError = Boolean(geoError) || isWeatherError || !weatherData?.current;
+
+	const headlineValue = isLoading
+		? "..."
+		: geoError
+			? t("resumes.resumeWeatherCard.locationError")
+			: hasError
+				? t("resumes.resumeWeatherCard.apiError")
+				: `${Math.round(weatherData.current.temperature)}${weatherData.units.temperature}`;
+
+	const weatherDescription =
+		!isLoading && !hasError
+			? (() => {
+					const code = weatherData?.current?.weatherCode;
+					if (code == null)
+						return weatherData?.current?.weatherDescription || "";
+					const key = weatherDescriptionKeyByCode[code];
+					return key
+						? t("weatherDescriptions." + key, {
+								ns: "dashboard",
+								defaultValue: weatherData?.current?.weatherDescription || "",
+							})
+						: weatherData?.current?.weatherDescription || "";
+				})()
+			: "";
+
+	const feelsLikeValue =
+		weatherData?.current && weatherData?.units
+			? `${Math.round(weatherData.current.apparentTemperature)}${weatherData.units.temperature}`
+			: "-";
+	const windValue =
+		weatherData?.current && weatherData?.units
+			? `${Math.round(weatherData.current.windSpeed)} ${weatherData.units.windSpeed}`
+			: "-";
+	const humidityValue =
+		weatherData?.current && weatherData?.units
+			? `${weatherData.current.humidity}${weatherData.units.humidity}`
+			: "-";
+	const rainChanceValue =
+		weatherData?.daily[0]?.precipitationProbabilityMax != null
+			? `${weatherData.daily[0].precipitationProbabilityMax}%`
+			: "-";
+
+	return (
+		<Card
+			className={cn(
+				"h-full border-l-4 border-l-info py-4 gap-0",
+				"min-h-34",
+				className,
+			)}
+		>
+			<CardContent className="px-4">
+				<div className="flex items-start justify-between gap-3">
+					<div className="min-w-0">
+						<p className="text-body text-muted-foreground">
+							{t("resumes.resumeWeatherCard.label")}
+						</p>
+						<p className="text-h1 sm:text-display font-bold text-foreground leading-none wrap-break-word">
+							{headlineValue}
+						</p>
+						{weatherDescription ? (
+							<p className="text-small text-muted-foreground mt-1 wrap-break-word">
+								{weatherDescription}
+							</p>
+						) : null}
+					</div>
+					<Cloud
+						className="w-7 h-7 text-info shrink-0 mt-1"
+						aria-hidden="true"
+					/>
+				</div>
+
+				{!isLoading && !hasError ? (
+					<div className="mt-4 grid grid-cols-2 gap-2 sm:gap-2.5">
+						<WeatherMetric
+							label={t("resumes.resumeWeatherCard.feelsLike")}
+							value={feelsLikeValue}
+						/>
+						<WeatherMetric
+							label={t("resumes.resumeWeatherCard.wind")}
+							value={windValue}
+						/>
+						<WeatherMetric
+							label={t("resumes.resumeWeatherCard.humidity")}
+							value={humidityValue}
+						/>
+						<WeatherMetric
+							label={t("resumes.resumeWeatherCard.rainChance")}
+							value={rainChanceValue}
+						/>
+					</div>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/lib/i18n/en/dashboard.json
+++ b/src/lib/i18n/en/dashboard.json
@@ -12,7 +12,11 @@
             "value": "24°C",
             "trendValue": "Sunny",
             "locationError": "Location unavailable",
-            "apiError": "Weather unavailable"
+            "apiError": "Weather unavailable",
+            "feelsLike": "Feels like",
+            "wind": "Wind",
+            "humidity": "Humidity",
+            "rainChance": "Rain chance"
         },
         "resumeHealthCard": {
             "label": "Health Alerts",

--- a/src/lib/i18n/en/flocks.json
+++ b/src/lib/i18n/en/flocks.json
@@ -118,7 +118,36 @@
       "loading": "Loading egg collections...",
       "empty": "No egg collections found",
       "layRate": "Lay rate: {{layRate}}%",
-      "totals": "Total: {{totalEggs}} • Usable: {{usableEggs}} • Broken: {{brokenEggs}}"
+      "totals": "Total: {{totalEggs}} • Usable: {{usableEggs}} • Broken: {{brokenEggs}}",
+      "record": "Record eggs",
+      "edit": "Edit",
+      "delete": "Delete",
+      "recordSuccess": "Egg collection recorded",
+      "updateSuccess": "Egg collection updated",
+      "deleteSuccess": "Egg collection deleted",
+      "form": {
+        "date": "Collection date",
+        "totalEggs": "Total eggs",
+        "brokenEggs": "Broken eggs",
+        "notes": "Notes",
+        "notesPlaceholder": "Optional notes...",
+        "usableHelp": "Usable: {{count}} eggs",
+        "submit": "Record",
+        "submitting": "Saving...",
+        "update": "Update",
+        "updating": "Updating...",
+        "brokenExceedsTotal": "Cannot exceed total eggs"
+      },
+      "recordModal": {
+        "title": "Record egg collection",
+        "editTitle": "Edit collection"
+      },
+      "deleteDialog": {
+        "title": "Delete collection",
+        "description": "Are you sure you want to delete this egg collection? This action cannot be undone.",
+        "confirm": "Delete",
+        "cancel": "Cancel"
+      }
     }
   },
   "deleteDialog": {

--- a/src/lib/i18n/es/dashboard.json
+++ b/src/lib/i18n/es/dashboard.json
@@ -1,5 +1,7 @@
 {
-        "tasks": {
+    "title": "Panel de control",
+    "dashboardSubtitle": "Bienvenido de nuevo a tu granja digital",
+    "tasks": {
             "title": "Tarea completada",
             "description": "Alimentación matutina completada",
             "timestamp": "Hace 8 horas"
@@ -63,7 +65,11 @@
             "value": "24°C",
             "trendValue": "Soleado",
             "locationError": "Ubicación no disponible",
-            "apiError": "Clima no disponible"
+            "apiError": "Clima no disponible",
+            "feelsLike": "Sensación térmica",
+            "wind": "Viento",
+            "humidity": "Humedad",
+            "rainChance": "Probabilidad de lluvia"
         },
         "resumeHealthCard": {
             "label": "Alertas de salud",

--- a/src/lib/i18n/es/flocks.json
+++ b/src/lib/i18n/es/flocks.json
@@ -118,7 +118,36 @@
       "loading": "Cargando recolecciones...",
       "empty": "No se encontraron recolecciones",
       "layRate": "Tasa de postura: {{layRate}}%",
-      "totals": "Total: {{totalEggs}} • Aprovechables: {{usableEggs}} • Rotos: {{brokenEggs}}"
+      "totals": "Total: {{totalEggs}} • Aprovechables: {{usableEggs}} • Rotos: {{brokenEggs}}",
+      "record": "Registrar huevos",
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "recordSuccess": "Recolección registrada",
+      "updateSuccess": "Recolección actualizada",
+      "deleteSuccess": "Recolección eliminada",
+      "form": {
+        "date": "Fecha de recolección",
+        "totalEggs": "Total de huevos",
+        "brokenEggs": "Huevos rotos",
+        "notes": "Notas",
+        "notesPlaceholder": "Notas opcionales...",
+        "usableHelp": "Aprovechables: {{count}} huevos",
+        "submit": "Registrar",
+        "submitting": "Guardando...",
+        "update": "Actualizar",
+        "updating": "Actualizando...",
+        "brokenExceedsTotal": "No puede superar el total de huevos"
+      },
+      "recordModal": {
+        "title": "Registrar recolección",
+        "editTitle": "Editar recolección"
+      },
+      "deleteDialog": {
+        "title": "Eliminar recolección",
+        "description": "¿Estás seguro de que quieres eliminar esta recolección? Esta acción no se puede deshacer.",
+        "confirm": "Eliminar",
+        "cancel": "Cancelar"
+      }
     }
   },
   "deleteDialog": {

--- a/src/routes/_private/_privatelayout/farm/$farmId/dashboard.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/dashboard.tsx
@@ -9,14 +9,7 @@ import { ScrollablePageLayout } from "@/components/layout/scrollable-page-layout
 import { StatsWidget } from "@/components/common/stats-widget";
 import { ActivityFeed } from "@/components/common/activity-feed";
 import { QuickActionCard } from "@/components/common/quick-action-card";
-import {
-	Beef,
-	Cloud,
-	AlertTriangle,
-	Plus,
-	Stethoscope,
-	Heart,
-} from "lucide-react";
+import { Beef, AlertTriangle, Plus, Stethoscope, Heart } from "lucide-react";
 import {
 	useGetAnimalStats,
 	useGetAnimalsByFarmId,
@@ -25,8 +18,8 @@ import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { useCurrentLocation } from "@/features/weather/use-current-location";
 import { useGetWeather } from "@/features/weather/api/weather-queries";
-import { weatherDescriptionKeyByCode } from "@/features/weather/weather-description-map";
 import { NewAnimalModal } from "@/features/animal/components/new-animal-modal/new-animal-modal";
+import { DashboardWeatherCard } from "@/features/weather/components/dashboard-weather-card";
 
 export const Route = createFileRoute(
 	"/_private/_privatelayout/farm/$farmId/dashboard",
@@ -132,41 +125,12 @@ function RouteComponent() {
 							/>
 						</Link>
 
-						<StatsWidget
-							icon={Cloud}
-							iconColor="text-info"
-							borderColor="border-l-info"
-							label={t("resumes.resumeWeatherCard.label")}
-							value={
-								geoLoading
-									? "..."
-									: geoError
-										? t("resumes.resumeWeatherCard.locationError")
-										: isWeatherLoading
-											? "..."
-											: isWeatherError || !weatherData?.current
-												? t("resumes.resumeWeatherCard.apiError")
-												: `${Math.round(weatherData.current.temperature)}${weatherData.units.temperature}`
-							}
-							trend={{
-								value:
-									isWeatherLoading || geoLoading
-										? ""
-										: (() => {
-												const code = weatherData?.current?.weatherCode;
-												if (code == null)
-													return weatherData?.current?.weatherDescription || "";
-												const key = weatherDescriptionKeyByCode[code];
-												return key
-													? t("weatherDescriptions." + key, {
-															ns: "dashboard",
-															defaultValue:
-																weatherData?.current?.weatherDescription || "",
-														})
-													: weatherData?.current?.weatherDescription || "";
-											})(),
-								direction: "neutral",
-							}}
+						<DashboardWeatherCard
+							weatherData={weatherData}
+							isGeoLoading={geoLoading}
+							geoError={geoError}
+							isWeatherLoading={isWeatherLoading}
+							isWeatherError={isWeatherError}
 						/>
 
 						<StatsWidget

--- a/src/routes/_private/_privatelayout/farm/$farmId/flocks.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/flocks.tsx
@@ -14,7 +14,7 @@ import type {
 	IFlockStatus,
 	IFlockType,
 } from "@/features/flock/types/flock-types";
-import { createFileRoute, useParams } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useParams } from "@tanstack/react-router";
 import { ListFilter, Plus, Tractor } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -29,8 +29,18 @@ export const Route = createFileRoute(
 const pageSizeOptions = [10, 20, 50];
 
 function RouteComponent() {
+	const { farmId, flockId } = useParams({ strict: false });
+
+	if (flockId) {
+		return <Outlet />;
+	}
+
+	return <FlocksListPage farmId={farmId!} />;
+}
+
+function FlocksListPage({ farmId }: { farmId: string }) {
 	const { t } = useTranslation("flocks");
-	const { farmId } = useParams({ strict: false });
+
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useState(10);
 	const [filters, setFilters] = useState<Partial<IFlockListFilters>>({});

--- a/src/routes/_private/_privatelayout/farm/$farmId/flocks/$flockId.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/flocks/$flockId.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/features/flock/api/flock-queries";
 import { EggCollectionsList } from "@/features/flock/components/egg-collections-list";
 import { FlockEventsList } from "@/features/flock/components/flock-events-list";
+import { RecordEggCollectionModal } from "@/features/flock/components/record-egg-collection-modal";
+import { UpdateFlockCountModal } from "@/features/flock/components/update-flock-count-modal";
 import { createFileRoute, useParams } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 
@@ -19,7 +21,7 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
 	const { t } = useTranslation("flocks");
-	const { flockId } = useParams({ strict: false });
+	const { flockId, farmId } = useParams({ strict: false });
 	const getErrorMessage = (error: unknown, fallback: string): string => {
 		if (error instanceof Error && error.message) {
 			return error.message;
@@ -49,6 +51,15 @@ function RouteComponent() {
 		page: 1,
 		limit: 10,
 	});
+	const { data: historyEventData } = useGetFlockEventsPage({
+		flockId: flockId!,
+		page: 1,
+		limit: 1000,
+	});
+
+	const isLayingFlock =
+		flock?.flockType === "layers" || flock?.flockType === "dual_purpose";
+
 	const {
 		data: eggCollectionData,
 		isPending: isEggCollectionsLoading,
@@ -68,6 +79,10 @@ function RouteComponent() {
 				<PageHeader
 					title={flock?.name ?? t("detail.title")}
 					description={t("detail.description")}
+					backLink={{
+						to: "/farm/$farmId/flocks",
+						params: { farmId: farmId! },
+					}}
 				/>
 			}
 		>
@@ -110,6 +125,13 @@ function RouteComponent() {
 						</div>
 					</div>
 
+					<UpdateFlockCountModal
+						flock={flock!}
+						farmId={farmId!}
+						buttonClassName="h-11 w-full justify-center rounded-xl border border-border/50 bg-transparent font-bold text-foreground hover:bg-muted/50"
+						editorClassName="w-full min-w-0"
+					/>
+
 					<section className="space-y-2">
 						<h2 className="text-h2">{t("detail.events.title")}</h2>
 						{isEventsLoading ? (
@@ -135,35 +157,48 @@ function RouteComponent() {
 						)}
 					</section>
 
-					<section className="space-y-2">
-						<h2 className="text-h2">{t("detail.eggCollections.title")}</h2>
-						{isEggCollectionsLoading ? (
-							<div className="rounded-card border p-6 text-center text-muted-foreground">
-								{t("detail.eggCollections.loading")}
+					{isLayingFlock && (
+						<section className="space-y-2">
+							<div className="flex items-center justify-between gap-2">
+								<h2 className="text-h2">{t("detail.eggCollections.title")}</h2>
+								<RecordEggCollectionModal
+									mode="create"
+									flockId={flockId!}
+									farmId={farmId!}
+								/>
 							</div>
-						) : isEggCollectionsError ? (
-							<div className="rounded-card border p-4 flex flex-col gap-2">
-								<p className="text-destructive text-sm">
-									{getErrorMessage(
-										eggCollectionsError,
-										t("detail.eggCollections.loading"),
-									)}
-								</p>
-								<div>
-									<Button
-										variant="outline"
-										onClick={() => void refetchEggCollections()}
-									>
-										{t("page.retry")}
-									</Button>
+							{isEggCollectionsLoading ? (
+								<div className="rounded-card border p-6 text-center text-muted-foreground">
+									{t("detail.eggCollections.loading")}
 								</div>
-							</div>
-						) : (
-							<EggCollectionsList
-								eggCollections={eggCollectionData?.items ?? []}
-							/>
-						)}
-					</section>
+							) : isEggCollectionsError ? (
+								<div className="rounded-card border p-4 flex flex-col gap-2">
+									<p className="text-destructive text-sm">
+										{getErrorMessage(
+											eggCollectionsError,
+											t("detail.eggCollections.loading"),
+										)}
+									</p>
+									<div>
+										<Button
+											variant="outline"
+											onClick={() => void refetchEggCollections()}
+										>
+											{t("page.retry")}
+										</Button>
+									</div>
+								</div>
+							) : (
+								<EggCollectionsList
+									eggCollections={eggCollectionData?.items ?? []}
+									flockId={flockId!}
+									farmId={farmId!}
+									flockInitialCount={flock?.initialCount ?? 0}
+									flockEventsForHistory={historyEventData?.items ?? []}
+								/>
+							)}
+						</section>
+					)}
 				</div>
 			)}
 		</ScrollablePageLayout>


### PR DESCRIPTION
## Summary
Adds dashboard weather integration and introduces flock detail egg-collection management with improved detail navigation.

## What changed
- Added dashboard weather summary card and localized dashboard header content.
- Implemented egg collection CRUD in flock detail (create, edit, delete) with API/query wiring.
- Added flock list-to-detail navigation, detail back navigation, and count editing in detail view.
- Stabilized displayed egg lay rate based on historical flock state at collection date.

## Validation performed
- Lint: Passed
- Build: Passed

## Risks/notes
- Out-of-scope for branch naming: this branch also includes flock feature work in addition to weather integration.
- Lay-rate stabilization is currently handled in frontend reconstruction from events; backend snapshot support would be more robust long-term.