### PR TITLE
feat(inventory): add feed inventory modules and route

### DIFF
--- a/docs/feed-inventory-feature-guide.md
+++ b/docs/feed-inventory-feature-guide.md
@@ -1,0 +1,274 @@
+# Feed Inventory Feature Guide
+## Understanding the 3-Phase Implementation (Phase 1, 2 & 3)
+
+---
+
+## 🎯 What You Can Do Now
+
+The feed inventory feature streamlines how you track, schedule, and report on feed purchases and consumption across your farm. It connects purchasing, daily feeding activities, and cost analysis into one unified system.
+
+---
+
+## 📋 Phase 1: Foundation — Feed Tracking & Consumption
+
+### What This Phase Added
+- **Feed lot management** — Record when you buy feed (quantity, price, date, supplier)
+- **Consumption logging** — Record when flocks eat feed (which feed, how much, which flock, reason)
+- **Stock tracking** — Automatically calculates remaining feed per lot
+
+### How to Use It
+
+#### Create a Feed Lot (Record a Purchase)
+1. Go to **Inventory** → **Feed Lots** tab
+2. Click **"New lot"**
+3. Fill in:
+   - **Feed type** — Select from your available feed types (hay, grain, pellets, etc.)
+   - **Quantity** — How many kilos you bought
+   - **Unit price** — Cost per kilo (e.g., $5.50/kg)
+   - **Purchase date** — When you bought it
+   - **Supplier** — Optional notes on where it came from
+4. Click **Create** — The system records the lot and automatically shows remaining stock
+
+#### Log Feed Consumed
+1. Go to **Inventory** → **Feed Log** tab
+2. Click **"Log feeding"**
+3. Fill in:
+   - **Feed type** — Which feed was consumed
+   - **Flock** — Which flock ate it (or leave blank for waste/transfer)
+   - **Reason** — Feeding, Waste, Transfer, or Adjustment
+   - **Quantity** — How many kilos
+   - **Date** — When this happened
+4. Click **Create** — The system deducts from the lot and tracks consumption
+
+#### View Stock Status
+- In the **Feed Lots** tab, each lot shows:
+  - **"X / Y kg remaining"** — How much is left from the original purchase
+  - Example: "48 / 100 kg remaining" means you've used 52 kg
+
+---
+
+## ⏰ Phase 2: Automation — Feeding Schedules & Smart Logging
+
+### What This Phase Added
+- **Feeding schedules** — Pre-define daily feeding targets per flock
+- **Smart feeding action** — Log today's feeding in one click based on schedule
+- **Date-range planning** — Set when schedules are active (start date → end date)
+
+### How to Use It
+
+#### Create a Feeding Schedule
+1. Go to **Inventory** → **Schedules** tab
+2. Click **"New schedule"**
+3. Fill in:
+   - **Flock** — Which flock should eat this feed
+   - **Feed type** — What feed to use
+   - **Daily quantity** — Show many kg per day (e.g., 5 kg/day)
+   - **Active from** — When schedule starts (date picker)
+   - **Active to** — When schedule ends, optional (leave blank if ongoing)
+4. Click **Create** — Schedule is ready
+
+#### View & Manage Schedules
+- The **Schedules** tab shows all active schedules
+- Each schedule displays:
+  - **Flock name** and **Feed type**
+  - **5 kg / day** (the daily target)
+  - **Jan 01 2026 to Ongoing** (active period, or end date if closed)
+  - Status badge: **Active** or **Inactive**
+
+#### Close a Schedule
+1. In the **Schedules** tab, find an active schedule
+2. Click **"Close"** button
+3. The schedule's **Active to** date is set to today
+4. Future feeding will use only active schedules
+
+#### Log Today's Feeding (Quick Action)
+1. Go to a specific **Flock** detail page
+2. In the top section, click **"Log today's feeding"**
+3. The system automatically:
+   - Finds all active feeding schedules for that flock
+   - Uses FIFO (First-In-First-Out) to select which lots to draw from
+   - Records the consumption with today's date
+   - Deducts from lot stock
+4. A success message shows what was logged
+
+**Example:** If you have two active schedules (5 kg hay, 2 kg grain), clicking once logs both in one action.
+
+---
+
+## 💰 Phase 3: Reporting — Financial Integration & Cost Analysis
+
+### What This Phase Added
+- **Auto-created expenses** — Feed purchases automatically link to your expense ledger
+- **Cost-by-flock report** — See how much each flock costs to feed (broken down by feed type)
+- **Cost-by-lot report** — Deep dive into a specific purchase: who ate it, how much, total cost
+- **FIFO costing** — All costs use the actual prices from when feed was purchased
+
+### How to Use It
+
+#### View Cost by Flock Report
+1. Go to **Inventory** → **Reports** tab
+2. In **Report filters**, optionally set:
+   - **From / To** dates to narrow the time period
+   - **Flock** dropdown to focus on one flock (or "All")
+3. The **Cost by flock** card shows:
+   - Each flock's total feed cost (e.g., **$150.50**)
+   - Total quantity consumed (e.g., **500 kg**)
+   - Breakdown by feed type:
+     - **Hay: 300 kg** (cost calculation)
+     - **Grain: 200 kg** (cost calculation)
+
+**What this tells you:**
+- Which flocks are most expensive to feed
+- How your costs change over time
+- Cost drivers (is grain more expensive than hay?)
+
+#### View Cost by Lot Report
+1. Go to **Inventory** → **Reports** tab
+2. Select a **Lot** from the dropdown (shows all your purchases)
+3. The **Cost by lot** card shows:
+   - **Purchased:** 100 kg (how much you bought)
+   - **Drawn:** 85 kg (how much was consumed)
+   - **Remaining:** 15 kg (still in stock)
+   - **Total Cost:** $425.00 (what you paid for what was used)
+   - **Unit Cost:** $5.00/kg (your actual cost per kg)
+
+4. Below that, a **"Consumption by flock"** table shows:
+   - **Flock A:** 50 kg ($250.00)
+   - **Flock B:** 35 kg ($175.00)
+   - **Waste/Transfers:** (if any)
+
+**What this tells you:**
+- How a specific feed batch was used across flocks
+- Cost per flock for that specific lot
+- Remaining stock and when you'll need to reorder
+
+#### Track Feed Purchases in Your Expense Ledger
+1. Go to **Financial** (Expenses)
+2. The ledger now shows auto-created feed purchase rows:
+   - **Description:** "Feed purchase: Hay" or "Feed purchase: Grain"
+   - **Amount:** Exact cost based on qty × unit price (e.g., $250.00)
+   - **Date:** Purchase date
+   - **Species:** Marked as **"Farm-wide"** (feed benefits all flocks)
+
+---
+
+## 🔄 How the Phases Work Together
+
+### The Complete Workflow
+
+1. **Phase 1: You buy feed**
+   - Create a Feed Lot (quantity, price, date)
+   - System records the purchase and tracks stock
+   
+2. **Phase 2: You plan and execute feeding**
+   - Create Feeding Schedules (daily targets per flock)
+   - Click "Log today's feeding" to record consumption
+   - System deducts from lots and tracks which flocks ate what
+   
+3. **Phase 3: You analyze costs**
+   - View **Cost by Flock** to see which flocks are expensive
+   - View **Cost by Lot** to see how a batch was used
+   - Review **Expense Ledger** to see feed purchases alongside other farm costs
+
+### Real Example: A Month of Feeding
+
+**Day 1 (Phase 1):**
+- You buy 100 kg of hay @ $5/kg = $500
+- System creates Lot #1 and expense record
+
+**Day 2–10 (Phase 2):**
+- You create schedule: Flock A gets 5 kg hay/day
+- Each day, you click "Log today's feeding"
+- Each click: logs 5 kg, deducts from Lot #1, records cost
+
+**Day 31 (Phase 3):**
+- You run the **Cost by Flock** report for the month
+- Shows: Flock A consumed 150 kg of hay for $750 total
+- You run **Cost by Lot** for Lot #1
+- Shows: 100 kg purchased, 100 kg drawn, $0 remaining stock
+
+---
+
+## 🎓 Key Concepts Explained
+
+### FIFO (First-In, First-Out)
+When logging feeding, the system automatically uses the oldest feed first. 
+- If you have Lot #1 (100 kg, $5/kg) and Lot #2 (100 kg, $8/kg)
+- Logging 150 kg uses: 100 kg from Lot #1 ($500) + 50 kg from Lot #2 ($400)
+- This matches real-world usage and ensures freshest feed is used last
+
+### Snapshot Costing
+Feed costs are locked at purchase time and don't change later.
+- Buy hay @ $5/kg, use it next month
+- Even if hay price drops to $3/kg, your consumption still costs $5/kg
+- This gives accurate historical cost reporting
+
+### Active Period
+Schedules have a start date (required) and end date (optional).
+- **Active from Jan 1, Active to Jan 31** = runs only in January
+- **Active from Jan 1, Active to (blank)** = runs from Jan 1 onwards indefinitely
+- Closing a schedule sets today as the end date automatically
+
+---
+
+## 📊 Questions You Can Answer Now
+
+1. **How much did it cost to feed each flock this month?**
+   → Cost by Flock report
+
+2. **Which feed type is most expensive?**
+   → Cost by Flock report, by feed type breakdown
+
+3. **What happened to that $500 batch of hay I bought?**
+   → Cost by Lot report for that specific lot
+
+4. **Is Flock A more expensive to feed than Flock B?**
+   → Compare Cost by Flock rows
+
+5. **How much feed stock do I have left?**
+   → Feed Lots tab shows remaining per lot
+
+6. **When should I reorder?**
+   → Check remaining stock in Feed Lots + consumption rate from Cost by Flock
+
+---
+
+## 💡 Pro Tips
+
+✅ **Create feeding schedules for consistency** — Don't manually log each day; set schedules and use one-click logging
+
+✅ **Use date ranges to track seasonal changes** — Close summer schedules, create winter ones
+
+✅ **Check Cost by Flock monthly** — Spot trends and identify which flocks are becoming expensive
+
+✅ **Review Cost by Lot after consumption** — Verify everything was tracked correctly
+
+✅ **Use "Waste" reason for spoilage** — So reports accurately show feed cost vs. consumption
+
+---
+
+## ❓ Troubleshooting
+
+**Q: "Log today's feeding" doesn't work**
+A: Check that:
+- You have at least one active feeding schedule for that flock (it won't appear unless active)
+- You have feed stock available (can't feed if out of stock)
+
+**Q: Cost by Flock report shows nothing**
+A: 
+- Check that you've actually logged consumption (it won't show without logs)
+- Verify the date range includes your feeding dates
+
+**Q: A schedule shows "Inactive" even though I just created it**
+A: 
+- Verify today's date is within the Active from → Active to range
+- Schedules only show as "Active" if today falls in that window
+
+---
+
+## 🚀 Next Steps
+
+1. **Start simple:** Create one feed lot and one flock's schedule
+2. **Log regularly:** Use "Log today's feeding" consistently
+3. **Review weekly:** Check Cost by Flock to track spending
+4. **Refine:** Adjust schedules as you learn your actual consumption rates

--- a/docs/phase-4-backend-brief.md
+++ b/docs/phase-4-backend-brief.md
@@ -1,0 +1,316 @@
+# Phase 4 Backend Brief: Flock Profitability & Economics
+## For Backend Dev (Using Claude)
+
+---
+
+## 🎯 Context & Vision
+
+### The Big Picture
+We're building a comprehensive farm economics system that answers: **"Which flocks are profitable, and which ones are costing us money?"**
+
+Currently (Phases 1-3):
+- ✅ We track **feed purchases** and **daily consumption per flock** 
+- ✅ We calculate **feed cost per flock**
+- ✅ We track **egg production per flock per day**
+
+But we're **missing the connection**: We can't yet compare daily income (eggs sold) vs. daily expenses (feed) per flock.
+
+### Original Idea (User's Request in Spanish)
+> "La idea era que se pudiera llevar un registro de gastos por diferentes tipos estos, entre ellos comida, y que se pudiera llevar un control de la cantidad que se usa y demas por cada flock/dia. Tambien se pudiera registrar la cantidad de huevos que cada flock de gallinas registra por dia... para calcular/estudiar el beneficio de cada flock."
+
+**Translation:** Track expenses by type (food, etc.), monitor consumption per flock/day, record egg production per day per flock, and calculate profit/loss per flock to study which ones are viable.
+
+---
+
+## 📋 Phase 4 Requirements
+
+### 1. **Global Egg Pricing Configuration**
+
+**What we need:**
+- A way to store egg unit prices globally (not per-flock, not per-species, truly global)
+- Eggs are counted by "Maple" stacks (30 eggs = 1 stack)
+- Therefore: Price is per egg, not per stack
+
+**Data Model:**
+```typescript
+interface IEggPricingConfig {
+  id: string;
+  farmId: string;
+  pricePerEgg: number; // e.g., $0.50
+  currency: string; // e.g., "USD"
+  effectiveFrom: Date;
+  effectiveTo: Date | null; // null = ongoing
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+**Endpoints needed:**
+- `GET /farms/{farmId}/egg-pricing` — Fetch current egg price
+- `POST /farms/{farmId}/egg-pricing` — Set/update egg price (only Maple version for now)
+- Endpoint should return only the **active** pricing rule (where today falls between effectiveFrom/effectiveTo)
+
+**Notes:**
+- Store pricing with date ranges so we can have historical pricing changes
+- For now, simple implementation: just one active price per farm at any time
+- Examples:
+  - Jan 1 – Jan 31: $0.50/egg
+  - Feb 1 – ongoing: $0.55/egg (price increase happened in Feb)
+
+---
+
+### 2. **Profitability Calculation Endpoint**
+
+**What we need:**
+An endpoint that calculates profit/loss per flock for a given period.
+
+**Input:**
+```typescript
+{
+  farmId: string;
+  flockId?: string; // optional: if provided, calculate for ONE flock; if omitted, calculate for ALL flocks
+  period: "daily" | "weekly" | "monthly";
+  from: string; // ISO date (YYYY-MM-DD)
+  to: string; // ISO date (YYYY-MM-DD)
+}
+```
+
+**Output:**
+```typescript
+interface IFlockProfitabilityReport {
+  farmId: string;
+  reportPeriod: "daily" | "weekly" | "monthly";
+  dateRange: {
+    from: string;
+    to: string;
+  };
+  flocks: IFlockProfitabilityRow[];
+}
+
+interface IFlockProfitabilityRow {
+  flockId: string;
+  flockName: string;
+  speciesId: string;
+  speciesName: string;
+  
+  // Egg income
+  eggsCollected: number; // total eggs in period
+  eggsCollectedStacks: number; // eggsCollected / 30
+  eggPrice: number; // price per egg at time of collection (or current if collection date older)
+  totalEggRevenue: number; // eggsCollected × eggPrice
+  
+  // Feed expenses
+  feedQuantity: number; // total kg consumed
+  totalFeedCost: number; // from existing feed-report costs
+  
+  // Profitability
+  totalExpenses: number; // for now, only feed (= totalFeedCost)
+  profit: number; // totalEggRevenue - totalExpenses
+  profitMargin: number; // profit / totalEggRevenue (as percentage, -100 to +inf)
+  
+  // Daily/weekly/monthly breakdown (if requested)
+  periodBreakdown?: IPeriodData[];
+}
+
+interface IPeriodData {
+  period: string; // "2026-01-01" for daily, "2026-W01" for weekly, "2026-01" for monthly
+  eggsCollected: number;
+  eggRevenue: number;
+  feedCost: number;
+  profit: number;
+  profitMargin: number;
+}
+```
+
+**Endpoint:**
+- `POST /farms/{farmId}/reports/flock-profitability` — Calculate profitability report
+- Or: `GET /farms/{farmId}/reports/flock-profitability?period=daily&from=2026-01-01&to=2026-01-31&flockId=abc123`
+
+---
+
+### 3. **Data Sources & Calculation Logic**
+
+**Egg Revenue:**
+- Query: `egg_collections` table filtered by `flockId`, `farmId`, date range
+- If multiple egg collections per day for same flock, sum them
+- Multiply by current farm egg price
+- Consider: **Eggs on Jan 15 should use Jan 15's egg price, not today's price**
+  - This means egg pricing should be historicized (see pricing config above)
+  - Alternative: Store egg price in egg_collections at collection time? (Discuss with frontend)
+
+**Feed Expenses:**
+- Already exists: `getFeedCostByFlock()` endpoint returns cost per flock for date range
+- Reuse that logic or create new query: `feed_costs` aggregated by flock for date range
+- Sum all feed types per flock
+
+**Profit Calculation:**
+```
+Profit = Total Egg Revenue - Total Feed Cost
+Margin % = Profit / Total Egg Revenue × 100
+  (e.g., $100 profit / $500 revenue = 20% margin)
+```
+
+---
+
+### 4. **Period Breakdown Logic**
+
+Support three period types:
+
+**Daily:**
+- Each row = one calendar day
+- Example output: "2026-01-15": {eggs: 30, revenue: $15, cost: $8, profit: $7}
+
+**Weekly:**
+- ISO week format: "2026-W03" = week 3 of 2026 (Jan 19–25)
+- Each row = one full week Mon–Sun
+- Sum all eggs/costs within that week
+
+**Monthly:**
+- Format: "2026-01" = January 2026
+- Each row = all data for that calendar month
+
+---
+
+## 🔧 Implementation Notes
+
+### Backend Architecture
+
+**Option A: New endpoint only**
+- Create new endpoint: `POST /reports/flock-profitability`
+- Queries existing `egg_collections` + existing `feed_costs`
+- No schema changes needed
+
+**Option B: Refactor with cached data** (future optimization)
+- Pre-calculate daily/weekly/monthly profitability and cache results
+- Faster reporting for large date ranges
+- Requires: new `flock_profitability_cache` table + cron job to refresh
+
+→ **Recommend: Start with Option A** (simpler, no new tables). If slow, optimize later.
+
+---
+
+### Egg Pricing Considerations
+
+**Decision: When to read egg price?**
+
+1. **At collection time** (store price in egg_collections row)
+   - Pro: Historical accuracy, fast queries
+   - Con: Data duplication, need migration
+
+2. **At report time** (join with egg_pricing config)
+   - Pro: Single source of truth, can retroactively change pricing logic
+   - Con: Slightly slower (join operation)
+
+→ **Recommend: Option 2 for now** (simpler, no data duplication)
+- At report time: For each egg collection, find the active egg price on that collection's date
+- Query: `SELECT * FROM egg_pricing WHERE farmId = X AND effectiveFrom <= collectionDate AND (effectiveTo IS NULL OR effectiveTo >= collectionDate)`
+
+---
+
+### Edge Cases to Handle
+
+1. **No egg collections in period** → Return row with 0 eggs, 0 revenue, but full feed cost
+   - Flock still has negative profit from feed cost alone
+
+2. **No feed logs in period** → Return row with egg revenue but 0 cost
+   - Flock shows as profitable (only eggs earned, no feed tracked)
+
+3. **No egg pricing configured** → Return error or default to $0?
+   - Recommend: Return error "Egg pricing not configured for this farm"
+
+4. **Flock deleted between period start and end** → Should query return historical flock name?
+   - Recommend: Yes, store flock name in report (in case flock is deleted later)
+
+5. **Multiple egg prices in one month** → Use price active on each collection date
+   - Should be automatic if using `effectiveFrom/effectiveTo` join
+
+---
+
+## 📊 Frontend Integration Points
+
+**Frontend will call this endpoint for:**
+1. Page load: Fetch profitability for "daily" period for current month
+2. Period toggle: Re-fetch data for "weekly" or "monthly"
+3. Flock detail: Fetch profitability for that specific flock
+4. Date range change: Re-fetch with new from/to dates
+
+**Frontend expects:**
+- Fast response (< 500ms) for typical farm (10–50 flocks)
+- Stable period keys ("2026-01-15" for daily, "2026-W03" for weekly, "2026-01" for monthly)
+- Null-safe values (no undefined, use 0 for missing data)
+
+---
+
+## 🎯 Recommendations & Future Phases
+
+### Phase 4A (Current – Eggs vs. Feed Only)
+- ✅ Global egg pricing config
+- ✅ Profitability endpoint (eggs vs. feed)
+- ✅ Three period types (daily/weekly/monthly)
+- ✅ Single flock or all flocks
+
+### Phase 4B (Future – Add Other Expenses)
+- Add `"Other expenses" per flock` (veterinary, equipment, labor)
+- Include in profit calculation: `Profit = Revenue - Feed - Other`
+- Query: `expenses` table filtered by flock, sum all except feed
+
+### Phase 4C (Future – Comparative Analysis)
+- Add endpoints: "Top 5 most profitable flocks," "Top 5 least profitable"
+- Add alerts: "Flock X has negative margin 3 weeks running"
+- Add trends: "Flock X profit trending up/down"
+
+### Phase 4D (Future – Production Optimization)
+- Cost per egg: `totalFeedCost / eggsCollected`
+- Benchmark: "Industry avg = $0.15/egg, you = $0.20/egg"
+- Recommendations: "Reduce feed cost by $X to break even"
+
+---
+
+## ❓ Questions for Backend Dev
+
+1. **Egg pricing storage:** Should we add `egg_pricing` table, or just a farm config (one global price)?
+   - Recommend: Table with date ranges (so we can track price history)
+
+2. **Performance:** Will joining `egg_collections` + `egg_pricing` be fast enough?
+   - Expected: < 500ms for 10 flocks, 1 year of data
+   - If slow, can we pre-calculate daily summaries?
+
+3. **Existing feed costs:** Can we reuse `getFeedCostByFlock()` logic for this?
+   - Or should we create a separate `_coreFlockProfitability()` internal function to avoid circular dependencies?
+
+4. **Null flocks in egg collections:** Does the egg_collections table have flockId?
+   - What if eggs collected but flockId not yet assigned?
+   - Should profitability query skip those rows, or group as "Unassigned"?
+
+---
+
+## 📝 Summary
+
+**What we're building:**
+- A profitability report per flock showing: eggs sold (revenue) vs. feed cost (expense) = profit/loss
+- Three period views: daily, weekly, monthly
+- Global egg pricing (configurable, with date ranges)
+- One endpoint that feeds all three periods
+
+**Why it matters:**
+- Identifies which flocks are worth keeping, which are dead weight
+- Guides decisions: "Flock A profitable, expand it. Flock B negative, reduce or optimize feed."
+- Enables financial analysis of the farm business
+
+**Timeline estimate:**
+- Egg pricing config: 2–3 hours
+- Profitability endpoint + logic: 4–5 hours
+- Testing & edge cases: 2–3 hours
+- **Total: ~9–11 hours** (or less if reusing existing feed_cost logic)
+
+---
+
+## 🚀 Next Steps
+
+1. Backend (you): Review this brief, ask questions, propose schema
+2. Frontend (me): Design UI mockup for profitability dashboard
+3. Backend: Implement Phase 4A endpoints
+4. Frontend: Wire up to UI, test with real data
+5. Deploy & gather feedback
+
+Let's go! 🎯

--- a/docs/phase-4-backend-brief.txt
+++ b/docs/phase-4-backend-brief.txt
@@ -1,0 +1,316 @@
+# Phase 4 Backend Brief: Flock Profitability & Economics
+## For Backend Dev (Using Claude)
+
+---
+
+## 🎯 Context & Vision
+
+### The Big Picture
+We're building a comprehensive farm economics system that answers: **"Which flocks are profitable, and which ones are costing us money?"**
+
+Currently (Phases 1-3):
+- ✅ We track **feed purchases** and **daily consumption per flock** 
+- ✅ We calculate **feed cost per flock**
+- ✅ We track **egg production per flock per day**
+
+But we're **missing the connection**: We can't yet compare daily income (eggs sold) vs. daily expenses (feed) per flock.
+
+### Original Idea (User's Request in Spanish)
+> "La idea era que se pudiera llevar un registro de gastos por diferentes tipos estos, entre ellos comida, y que se pudiera llevar un control de la cantidad que se usa y demas por cada flock/dia. Tambien se pudiera registrar la cantidad de huevos que cada flock de gallinas registra por dia... para calcular/estudiar el beneficio de cada flock."
+
+**Translation:** Track expenses by type (food, etc.), monitor consumption per flock/day, record egg production per day per flock, and calculate profit/loss per flock to study which ones are viable.
+
+---
+
+## 📋 Phase 4 Requirements
+
+### 1. **Global Egg Pricing Configuration**
+
+**What we need:**
+- A way to store egg unit prices globally (not per-flock, not per-species, truly global)
+- Eggs are counted by "Maple" stacks (30 eggs = 1 stack)
+- Therefore: Price is per egg, not per stack
+
+**Data Model:**
+```typescript
+interface IEggPricingConfig {
+  id: string;
+  farmId: string;
+  pricePerEgg: number; // e.g., $0.50
+  currency: string; // e.g., "USD"
+  effectiveFrom: Date;
+  effectiveTo: Date | null; // null = ongoing
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+**Endpoints needed:**
+- `GET /farms/{farmId}/egg-pricing` — Fetch current egg price
+- `POST /farms/{farmId}/egg-pricing` — Set/update egg price (only Maple version for now)
+- Endpoint should return only the **active** pricing rule (where today falls between effectiveFrom/effectiveTo)
+
+**Notes:**
+- Store pricing with date ranges so we can have historical pricing changes
+- For now, simple implementation: just one active price per farm at any time
+- Examples:
+  - Jan 1 – Jan 31: $0.50/egg
+  - Feb 1 – ongoing: $0.55/egg (price increase happened in Feb)
+
+---
+
+### 2. **Profitability Calculation Endpoint**
+
+**What we need:**
+An endpoint that calculates profit/loss per flock for a given period.
+
+**Input:**
+```typescript
+{
+  farmId: string;
+  flockId?: string; // optional: if provided, calculate for ONE flock; if omitted, calculate for ALL flocks
+  period: "daily" | "weekly" | "monthly";
+  from: string; // ISO date (YYYY-MM-DD)
+  to: string; // ISO date (YYYY-MM-DD)
+}
+```
+
+**Output:**
+```typescript
+interface IFlockProfitabilityReport {
+  farmId: string;
+  reportPeriod: "daily" | "weekly" | "monthly";
+  dateRange: {
+    from: string;
+    to: string;
+  };
+  flocks: IFlockProfitabilityRow[];
+}
+
+interface IFlockProfitabilityRow {
+  flockId: string;
+  flockName: string;
+  speciesId: string;
+  speciesName: string;
+  
+  // Egg income
+  eggsCollected: number; // total eggs in period
+  eggsCollectedStacks: number; // eggsCollected / 30
+  eggPrice: number; // price per egg at time of collection (or current if collection date older)
+  totalEggRevenue: number; // eggsCollected × eggPrice
+  
+  // Feed expenses
+  feedQuantity: number; // total kg consumed
+  totalFeedCost: number; // from existing feed-report costs
+  
+  // Profitability
+  totalExpenses: number; // for now, only feed (= totalFeedCost)
+  profit: number; // totalEggRevenue - totalExpenses
+  profitMargin: number; // profit / totalEggRevenue (as percentage, -100 to +inf)
+  
+  // Daily/weekly/monthly breakdown (if requested)
+  periodBreakdown?: IPeriodData[];
+}
+
+interface IPeriodData {
+  period: string; // "2026-01-01" for daily, "2026-W01" for weekly, "2026-01" for monthly
+  eggsCollected: number;
+  eggRevenue: number;
+  feedCost: number;
+  profit: number;
+  profitMargin: number;
+}
+```
+
+**Endpoint:**
+- `POST /farms/{farmId}/reports/flock-profitability` — Calculate profitability report
+- Or: `GET /farms/{farmId}/reports/flock-profitability?period=daily&from=2026-01-01&to=2026-01-31&flockId=abc123`
+
+---
+
+### 3. **Data Sources & Calculation Logic**
+
+**Egg Revenue:**
+- Query: `egg_collections` table filtered by `flockId`, `farmId`, date range
+- If multiple egg collections per day for same flock, sum them
+- Multiply by current farm egg price
+- Consider: **Eggs on Jan 15 should use Jan 15's egg price, not today's price**
+  - This means egg pricing should be historicized (see pricing config above)
+  - Alternative: Store egg price in egg_collections at collection time? (Discuss with frontend)
+
+**Feed Expenses:**
+- Already exists: `getFeedCostByFlock()` endpoint returns cost per flock for date range
+- Reuse that logic or create new query: `feed_costs` aggregated by flock for date range
+- Sum all feed types per flock
+
+**Profit Calculation:**
+```
+Profit = Total Egg Revenue - Total Feed Cost
+Margin % = Profit / Total Egg Revenue × 100
+  (e.g., $100 profit / $500 revenue = 20% margin)
+```
+
+---
+
+### 4. **Period Breakdown Logic**
+
+Support three period types:
+
+**Daily:**
+- Each row = one calendar day
+- Example output: "2026-01-15": {eggs: 30, revenue: $15, cost: $8, profit: $7}
+
+**Weekly:**
+- ISO week format: "2026-W03" = week 3 of 2026 (Jan 19–25)
+- Each row = one full week Mon–Sun
+- Sum all eggs/costs within that week
+
+**Monthly:**
+- Format: "2026-01" = January 2026
+- Each row = all data for that calendar month
+
+---
+
+## 🔧 Implementation Notes
+
+### Backend Architecture
+
+**Option A: New endpoint only**
+- Create new endpoint: `POST /reports/flock-profitability`
+- Queries existing `egg_collections` + existing `feed_costs`
+- No schema changes needed
+
+**Option B: Refactor with cached data** (future optimization)
+- Pre-calculate daily/weekly/monthly profitability and cache results
+- Faster reporting for large date ranges
+- Requires: new `flock_profitability_cache` table + cron job to refresh
+
+→ **Recommend: Start with Option A** (simpler, no new tables). If slow, optimize later.
+
+---
+
+### Egg Pricing Considerations
+
+**Decision: When to read egg price?**
+
+1. **At collection time** (store price in egg_collections row)
+   - Pro: Historical accuracy, fast queries
+   - Con: Data duplication, need migration
+
+2. **At report time** (join with egg_pricing config)
+   - Pro: Single source of truth, can retroactively change pricing logic
+   - Con: Slightly slower (join operation)
+
+→ **Recommend: Option 2 for now** (simpler, no data duplication)
+- At report time: For each egg collection, find the active egg price on that collection's date
+- Query: `SELECT * FROM egg_pricing WHERE farmId = X AND effectiveFrom <= collectionDate AND (effectiveTo IS NULL OR effectiveTo >= collectionDate)`
+
+---
+
+### Edge Cases to Handle
+
+1. **No egg collections in period** → Return row with 0 eggs, 0 revenue, but full feed cost
+   - Flock still has negative profit from feed cost alone
+
+2. **No feed logs in period** → Return row with egg revenue but 0 cost
+   - Flock shows as profitable (only eggs earned, no feed tracked)
+
+3. **No egg pricing configured** → Return error or default to $0?
+   - Recommend: Return error "Egg pricing not configured for this farm"
+
+4. **Flock deleted between period start and end** → Should query return historical flock name?
+   - Recommend: Yes, store flock name in report (in case flock is deleted later)
+
+5. **Multiple egg prices in one month** → Use price active on each collection date
+   - Should be automatic if using `effectiveFrom/effectiveTo` join
+
+---
+
+## 📊 Frontend Integration Points
+
+**Frontend will call this endpoint for:**
+1. Page load: Fetch profitability for "daily" period for current month
+2. Period toggle: Re-fetch data for "weekly" or "monthly"
+3. Flock detail: Fetch profitability for that specific flock
+4. Date range change: Re-fetch with new from/to dates
+
+**Frontend expects:**
+- Fast response (< 500ms) for typical farm (10–50 flocks)
+- Stable period keys ("2026-01-15" for daily, "2026-W03" for weekly, "2026-01" for monthly)
+- Null-safe values (no undefined, use 0 for missing data)
+
+---
+
+## 🎯 Recommendations & Future Phases
+
+### Phase 4A (Current – Eggs vs. Feed Only)
+- ✅ Global egg pricing config
+- ✅ Profitability endpoint (eggs vs. feed)
+- ✅ Three period types (daily/weekly/monthly)
+- ✅ Single flock or all flocks
+
+### Phase 4B (Future – Add Other Expenses)
+- Add `"Other expenses" per flock` (veterinary, equipment, labor)
+- Include in profit calculation: `Profit = Revenue - Feed - Other`
+- Query: `expenses` table filtered by flock, sum all except feed
+
+### Phase 4C (Future – Comparative Analysis)
+- Add endpoints: "Top 5 most profitable flocks," "Top 5 least profitable"
+- Add alerts: "Flock X has negative margin 3 weeks running"
+- Add trends: "Flock X profit trending up/down"
+
+### Phase 4D (Future – Production Optimization)
+- Cost per egg: `totalFeedCost / eggsCollected`
+- Benchmark: "Industry avg = $0.15/egg, you = $0.20/egg"
+- Recommendations: "Reduce feed cost by $X to break even"
+
+---
+
+## ❓ Questions for Backend Dev
+
+1. **Egg pricing storage:** Should we add `egg_pricing` table, or just a farm config (one global price)?
+   - Recommend: Table with date ranges (so we can track price history)
+
+2. **Performance:** Will joining `egg_collections` + `egg_pricing` be fast enough?
+   - Expected: < 500ms for 10 flocks, 1 year of data
+   - If slow, can we pre-calculate daily summaries?
+
+3. **Existing feed costs:** Can we reuse `getFeedCostByFlock()` logic for this?
+   - Or should we create a separate `_coreFlockProfitability()` internal function to avoid circular dependencies?
+
+4. **Null flocks in egg collections:** Does the egg_collections table have flockId?
+   - What if eggs collected but flockId not yet assigned?
+   - Should profitability query skip those rows, or group as "Unassigned"?
+
+---
+
+## 📝 Summary
+
+**What we're building:**
+- A profitability report per flock showing: eggs sold (revenue) vs. feed cost (expense) = profit/loss
+- Three period views: daily, weekly, monthly
+- Global egg pricing (configurable, with date ranges)
+- One endpoint that feeds all three periods
+
+**Why it matters:**
+- Identifies which flocks are worth keeping, which are dead weight
+- Guides decisions: "Flock A profitable, expand it. Flock B negative, reduce or optimize feed."
+- Enables financial analysis of the farm business
+
+**Timeline estimate:**
+- Egg pricing config: 2–3 hours
+- Profitability endpoint + logic: 4–5 hours
+- Testing & edge cases: 2–3 hours
+- **Total: ~9–11 hours** (or less if reusing existing feed_cost logic)
+
+---
+
+## 🚀 Next Steps
+
+1. Backend (you): Review this brief, ask questions, propose schema
+2. Frontend (me): Design UI mockup for profitability dashboard
+3. Backend: Implement Phase 4A endpoints
+4. Frontend: Wire up to UI, test with real data
+5. Deploy & gather feedback
+
+Let's go! 🎯

--- a/src/components/layout/bottom-tab-nav/bottom-tab-nav.tsx
+++ b/src/components/layout/bottom-tab-nav/bottom-tab-nav.tsx
@@ -1,53 +1,98 @@
-import { Link, useParams, useRouterState } from "@tanstack/react-router";
-import { Home, Beef, CheckSquare, User, ReceiptText, Bird } from "lucide-react";
+import {
+	Link,
+	useNavigate,
+	useParams,
+	useRouterState,
+} from "@tanstack/react-router";
+import { Home, Beef, User, ReceiptText, Bird, Package } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
+import { useState, useEffect, useRef } from "react";
 
-interface TabItem {
+interface DirectTab {
+	kind: "direct";
 	id: string;
 	label: string;
 	icon: React.ElementType;
 	path: string;
 }
 
+interface GroupChild {
+	id: string;
+	label: string;
+	icon: React.ElementType;
+	path: string;
+}
+
+interface GroupTab {
+	kind: "group";
+	id: string;
+	label: string;
+	icon: React.ElementType;
+	children: GroupChild[];
+}
+
+type NavTab = DirectTab | GroupTab;
+
 export function BottomTabNav() {
 	const { farmId } = useParams({ strict: false });
 	const router = useRouterState();
 	const currentPath = router.location.pathname;
 	const { t } = useTranslation("bottomTabNav");
+	const navigate = useNavigate();
+	const [openGroup, setOpenGroup] = useState<string | null>(null);
+	const navRef = useRef<HTMLElement>(null);
 
-	const tabs: TabItem[] = [
+	const tabs: NavTab[] = [
 		{
+			kind: "direct",
 			id: "dashboard",
 			label: t("tabs.dashboard"),
 			icon: Home,
 			path: `/farm/${farmId}/dashboard`,
 		},
 		{
-			id: "animals",
-			label: t("tabs.animals"),
+			kind: "group",
+			id: "livestock",
+			label: t("tabs.livestock"),
 			icon: Beef,
-			path: `/farm/${farmId}/species`,
+			children: [
+				{
+					id: "animals",
+					label: t("tabs.animals"),
+					icon: Beef,
+					path: `/farm/${farmId}/species`,
+				},
+				{
+					id: "flocks",
+					label: t("tabs.flocks"),
+					icon: Bird,
+					path: `/farm/${farmId}/flocks`,
+				},
+			],
 		},
 		{
-			id: "flocks",
-			label: t("tabs.flocks"),
-			icon: Bird,
-			path: `/farm/${farmId}/flocks`,
-		},
-		{
-			id: "expenses",
-			label: t("tabs.expenses"),
+			kind: "group",
+			id: "finance",
+			label: t("tabs.finance"),
 			icon: ReceiptText,
-			path: `/farm/${farmId}/expenses`,
+			children: [
+				{
+					id: "expenses",
+					label: t("tabs.expenses"),
+					icon: ReceiptText,
+					path: `/farm/${farmId}/expenses`,
+				},
+				{
+					id: "inventory",
+					label: t("tabs.inventory"),
+					icon: Package,
+					path: `/farm/${farmId}/inventory`,
+				},
+			],
 		},
 		{
-			id: "tasks",
-			label: t("tabs.tasks"),
-			icon: CheckSquare,
-			path: `/farm/${farmId}/tasks`,
-		},
-		{
+			kind: "direct",
 			id: "profile",
 			label: t("tabs.profile"),
 			icon: User,
@@ -55,50 +100,170 @@ export function BottomTabNav() {
 		},
 	];
 
-	const isActiveTab = (tabPath: string) => {
-		return currentPath.startsWith(tabPath);
-	};
+	const isPathActive = (path: string) => currentPath.startsWith(path);
+
+	const isGroupActive = (tab: GroupTab) =>
+		tab.children.some((c) => isPathActive(c.path));
+
+	useEffect(() => {
+		const handleClickOutside = (e: MouseEvent) => {
+			if (navRef.current && !navRef.current.contains(e.target as Node)) {
+				setOpenGroup(null);
+			}
+		};
+		document.addEventListener("mousedown", handleClickOutside);
+		return () => document.removeEventListener("mousedown", handleClickOutside);
+	}, []);
+
+	useEffect(() => {
+		const navElement = navRef.current;
+		if (!navElement) {
+			return;
+		}
+
+		const blockNavScroll = (event: Event) => {
+			event.preventDefault();
+			event.stopPropagation();
+		};
+
+		navElement.addEventListener("wheel", blockNavScroll, { passive: false });
+		navElement.addEventListener("touchmove", blockNavScroll, {
+			passive: false,
+		});
+
+		return () => {
+			navElement.removeEventListener("wheel", blockNavScroll);
+			navElement.removeEventListener("touchmove", blockNavScroll);
+		};
+	}, []);
 
 	return (
 		<nav
+			ref={navRef}
 			className="fixed bottom-0 left-0 right-0 bg-card border-t border-border z-50"
 			style={{ height: "68px" }}
-			aria-label="Main navigation"
+			aria-label={t("ariaLabel")}
 		>
-			<div className="h-full flex items-center justify-around max-w-screen-lg mx-auto px-2">
+			{/* Dropup panels */}
+			{/* Dropup panels — anchored above each group tab */}
+			{tabs.map((tab, tabIndex) => {
+				if (tab.kind !== "group" || openGroup !== tab.id) return null;
+				// Centre the panel over its own slot in the nav bar
+				const slotPct = 100 / tabs.length;
+				const leftPct = tabIndex * slotPct + slotPct / 2;
+				return (
+					<div
+						key={`dropup-${tab.id}`}
+						className="absolute bottom-full pb-2 pointer-events-none"
+						style={{ left: `${leftPct}%`, transform: "translateX(-50%)" }}
+					>
+						<div className="flex flex-col bg-card border border-border rounded-xl shadow-lg overflow-hidden pointer-events-auto min-w-40">
+							{tab.children.map((child) => {
+								const ChildIcon = child.icon;
+								const isActive = isPathActive(child.path);
+								return (
+									<button
+										key={child.id}
+										type="button"
+										onClick={() => {
+											setOpenGroup(null);
+											navigate({ to: child.path });
+										}}
+										className={cn(
+											"flex items-center gap-3 w-full px-4 py-3 transition-colors text-left",
+											"hover:bg-secondary/50",
+											isActive
+												? "text-primary font-semibold"
+												: "text-muted-foreground hover:text-foreground",
+										)}
+									>
+										<ChildIcon
+											className={cn(
+												"w-5 h-5 shrink-0",
+												isActive && "stroke-[2.5]",
+											)}
+											aria-hidden="true"
+										/>
+										<span className="text-sm">{child.label}</span>
+									</button>
+								);
+							})}
+						</div>
+					</div>
+				);
+			})}
+
+			<div className="h-full flex items-center justify-around max-w-5xl mx-auto px-2">
 				{tabs.map((tab) => {
 					const Icon = tab.icon;
-					const isActive = isActiveTab(tab.path);
 
+					if (tab.kind === "direct") {
+						const isActive = isPathActive(tab.path);
+						return (
+							<Link
+								key={tab.id}
+								to={tab.path}
+								className={cn(
+									"flex flex-col items-center justify-center gap-1 min-w-11 px-3 py-2 rounded-lg transition-colors",
+									"hover:bg-secondary/50",
+									isActive
+										? "text-primary"
+										: "text-muted-foreground hover:text-foreground",
+								)}
+								aria-current={isActive ? "page" : undefined}
+							>
+								<Icon
+									className={cn(
+										"w-6 h-6 transition-all",
+										isActive && "stroke-[2.5]",
+									)}
+									aria-hidden="true"
+								/>
+								<span
+									className={cn(
+										"text-caption font-medium transition-opacity",
+										isActive ? "opacity-100" : "opacity-0",
+									)}
+								>
+									{tab.label}
+								</span>
+							</Link>
+						);
+					}
+
+					// Group tab
+					const isActive = isGroupActive(tab);
+					const isOpen = openGroup === tab.id;
 					return (
-						<Link
+						<button
 							key={tab.id}
-							to={tab.path}
+							type="button"
+							onClick={() => setOpenGroup(isOpen ? null : tab.id)}
+							aria-expanded={isOpen}
 							className={cn(
-								"flex flex-col items-center justify-center gap-1 min-w-[44px] px-3 py-2 rounded-lg transition-colors",
+								"flex flex-col items-center justify-center gap-1 min-w-11 px-3 py-2 rounded-lg transition-colors",
 								"hover:bg-secondary/50",
-								isActive
+								isActive || isOpen
 									? "text-primary"
 									: "text-muted-foreground hover:text-foreground",
 							)}
-							aria-current={isActive ? "page" : undefined}
 						>
 							<Icon
 								className={cn(
 									"w-6 h-6 transition-all",
-									isActive && "stroke-[2.5]",
+									(isActive || isOpen) && "stroke-[2.5]",
 								)}
 								aria-hidden="true"
 							/>
 							<span
 								className={cn(
 									"text-caption font-medium transition-opacity",
-									isActive ? "opacity-100" : "opacity-0",
+									isActive || isOpen ? "opacity-100" : "opacity-0",
 								)}
 							>
 								{tab.label}
 							</span>
-						</Link>
+						</button>
 					);
 				})}
 			</div>

--- a/src/features/expense/components/expense-filter-panel.tsx
+++ b/src/features/expense/components/expense-filter-panel.tsx
@@ -11,6 +11,8 @@ import {
 import { financialTransactionTypeLabelKeys } from "@/features/expense/components/expense-labels";
 import { toYyyyMmDd } from "@/features/expense/components/expense-form-schema";
 import {
+	financialSummaryGroupBy,
+	financialSummaryPeriods,
 	financialTransactionTypes,
 	type IExpenseListFilters,
 } from "@/features/expense/types/expense-types";
@@ -51,6 +53,24 @@ export const ExpenseFilterPanel = ({
 		[t],
 	);
 
+	const groupByOptions = useMemo(
+		() =>
+			financialSummaryGroupBy.map((groupBy) => ({
+				label: t(`filters.groupByOptions.${groupBy}`),
+				value: groupBy,
+			})),
+		[t],
+	);
+
+	const periodOptions = useMemo(
+		() =>
+			financialSummaryPeriods.map((period) => ({
+				label: t(`filters.periodOptions.${period}`),
+				value: period,
+			})),
+		[t],
+	);
+
 	const speciesOptions = useMemo(
 		() => [
 			{ label: t("filters.allSpecies"), value: "all" },
@@ -82,6 +102,26 @@ export const ExpenseFilterPanel = ({
 		onChange({
 			...filters,
 			speciesId: value === "all" ? undefined : value,
+		});
+	};
+
+	const setGroupBy = (value: string) => {
+		onChange({
+			...filters,
+			groupBy:
+				value === "all"
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["groupBy"]>),
+		});
+	};
+
+	const setPeriod = (value: string) => {
+		onChange({
+			...filters,
+			period:
+				value === "all"
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["period"]>),
 		});
 	};
 
@@ -144,6 +184,56 @@ export const ExpenseFilterPanel = ({
 
 			<div className="space-y-1">
 				<p className="text-caption text-muted-foreground font-semibold uppercase tracking-wide">
+					{t("filters.groupByLabel")}
+				</p>
+				<Select
+					value={filters.groupBy ?? "all"}
+					onValueChange={setGroupBy}
+				>
+					<SelectTrigger className="h-10">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">{t("filters.allGroupBy")}</SelectItem>
+						{groupByOptions.map((option) => (
+							<SelectItem
+								key={option.value}
+								value={option.value}
+							>
+								{option.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			<div className="space-y-1">
+				<p className="text-caption text-muted-foreground font-semibold uppercase tracking-wide">
+					{t("filters.periodLabel")}
+				</p>
+				<Select
+					value={filters.period ?? "all"}
+					onValueChange={setPeriod}
+				>
+					<SelectTrigger className="h-10">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">{t("filters.allPeriods")}</SelectItem>
+						{periodOptions.map((option) => (
+							<SelectItem
+								key={option.value}
+								value={option.value}
+							>
+								{option.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			<div className="space-y-1">
+				<p className="text-caption text-muted-foreground font-semibold uppercase tracking-wide">
 					{t("filters.fromLabel")}
 				</p>
 				<div className="flex items-center gap-2">
@@ -190,7 +280,7 @@ export const ExpenseFilterPanel = ({
 		return (
 			<Card className="hidden md:flex lg:hidden border border-border/70 shadow-none py-4">
 				<CardContent className="px-4">
-					<div className="grid grid-cols-1 gap-3 xl:grid-cols-5">
+					<div className="grid grid-cols-1 gap-3 xl:grid-cols-7">
 						{controls}
 						<div className="flex items-end justify-end gap-2">
 							<Button

--- a/src/features/expense/components/expense-filter-sheet.tsx
+++ b/src/features/expense/components/expense-filter-sheet.tsx
@@ -18,6 +18,8 @@ import {
 import { financialTransactionTypeLabelKeys } from "@/features/expense/components/expense-labels";
 import { toYyyyMmDd } from "@/features/expense/components/expense-form-schema";
 import {
+	financialSummaryGroupBy,
+	financialSummaryPeriods,
 	financialTransactionTypes,
 	type IExpenseListFilters,
 } from "@/features/expense/types/expense-types";
@@ -58,6 +60,24 @@ export const ExpenseFilterSheet = ({
 		[t],
 	);
 
+	const groupByOptions = useMemo(
+		() =>
+			financialSummaryGroupBy.map((groupBy) => ({
+				label: t(`filters.groupByOptions.${groupBy}`),
+				value: groupBy,
+			})),
+		[t],
+	);
+
+	const periodOptions = useMemo(
+		() =>
+			financialSummaryPeriods.map((period) => ({
+				label: t(`filters.periodOptions.${period}`),
+				value: period,
+			})),
+		[t],
+	);
+
 	const speciesOptions = useMemo(
 		() => [
 			{ label: t("filters.allSpecies"), value: "all" },
@@ -89,6 +109,26 @@ export const ExpenseFilterSheet = ({
 		onChange({
 			...filters,
 			speciesId: value === "all" ? undefined : value,
+		});
+	};
+
+	const setGroupBy = (value: string) => {
+		onChange({
+			...filters,
+			groupBy:
+				value === "all"
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["groupBy"]>),
+		});
+	};
+
+	const setPeriod = (value: string) => {
+		onChange({
+			...filters,
+			period:
+				value === "all"
+					? undefined
+					: (value as NonNullable<IExpenseListFilters["period"]>),
 		});
 	};
 
@@ -157,6 +197,56 @@ export const ExpenseFilterSheet = ({
 							</SelectTrigger>
 							<SelectContent>
 								{speciesOptions.map((option) => (
+									<SelectItem
+										key={option.value}
+										value={option.value}
+									>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="space-y-2">
+						<label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+							{t("filters.groupByLabel")}
+						</label>
+						<Select
+							value={filters.groupBy ?? "all"}
+							onValueChange={setGroupBy}
+						>
+							<SelectTrigger className="h-12 rounded-2xl bg-muted/60 border-transparent px-4 text-base">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">{t("filters.allGroupBy")}</SelectItem>
+								{groupByOptions.map((option) => (
+									<SelectItem
+										key={option.value}
+										value={option.value}
+									>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="space-y-2">
+						<label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+							{t("filters.periodLabel")}
+						</label>
+						<Select
+							value={filters.period ?? "all"}
+							onValueChange={setPeriod}
+						>
+							<SelectTrigger className="h-12 rounded-2xl bg-muted/60 border-transparent px-4 text-base">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">{t("filters.allPeriods")}</SelectItem>
+								{periodOptions.map((option) => (
 									<SelectItem
 										key={option.value}
 										value={option.value}

--- a/src/features/expense/components/expense-list.tsx
+++ b/src/features/expense/components/expense-list.tsx
@@ -76,6 +76,7 @@ export const ExpenseList = ({
 		<div className="flex flex-col gap-3">
 			{expenses.map((expense) => {
 				const displayAmount = parseDecimal(expense.amount);
+				const isSystemGenerated = Boolean(expense.feedLotId);
 				const speciesName = expense.speciesId
 					? speciesNameById.get(expense.speciesId)
 					: undefined;
@@ -101,6 +102,11 @@ export const ExpenseList = ({
 										{speciesName && (
 											<Badge variant="secondary">{speciesName}</Badge>
 										)}
+										{isSystemGenerated && (
+											<Badge variant="secondary">
+												{t("list.systemGenerated")}
+											</Badge>
+										)}
 									</div>
 									<p className="text-sm text-muted-foreground">
 										{dateFormatter.format(new Date(`${expense.date}T00:00:00`))}
@@ -112,17 +118,25 @@ export const ExpenseList = ({
 										{currencyFormatter.format(displayAmount)}
 									</p>
 								</div>
-								<div className="flex gap-2">
-									<ExpenseFormModal
-										farmId={farmId}
-										filters={filters}
-										expense={expense}
-									/>
-									<DeleteExpenseDialog
-										expense={expense}
-										farmId={farmId}
-										filters={filters}
-									/>
+								<div className="flex gap-2 items-center">
+									{isSystemGenerated ? (
+										<p className="text-xs text-muted-foreground">
+											{t("list.systemGeneratedLocked")}
+										</p>
+									) : (
+										<>
+											<ExpenseFormModal
+												farmId={farmId}
+												filters={filters}
+												expense={expense}
+											/>
+											<DeleteExpenseDialog
+												expense={expense}
+												farmId={farmId}
+												filters={filters}
+											/>
+										</>
+									)}
 								</div>
 							</div>
 							<div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-sm">

--- a/src/features/expense/types/expense-types.ts
+++ b/src/features/expense/types/expense-types.ts
@@ -21,7 +21,8 @@ export interface IExpense {
 	amount: number;
 	type: FinancialTransactionType;
 	description: string | null;
-	speciesId: string;
+	speciesId: string | null;
+	feedLotId: string | null;
 	createdBy: string;
 	createdAt: string;
 	updatedAt: string;

--- a/src/features/feed-consumption/api/feed-consumption-api.ts
+++ b/src/features/feed-consumption/api/feed-consumption-api.ts
@@ -1,0 +1,61 @@
+import { axiosHelper } from "@/lib/axios/axios-helper";
+import type { IResponse } from "@/lib/axios";
+import type {
+	ICreateFeedConsumptionPayload,
+	IFeedConsumption,
+	IFeedConsumptionListFilters,
+} from "@/features/feed-consumption/types/feed-consumption-types";
+
+export const getFeedConsumptions = ({
+	filters,
+	page,
+	limit,
+}: {
+	filters?: Partial<IFeedConsumptionListFilters>;
+	page?: number;
+	limit?: number;
+}) =>
+	axiosHelper<IResponse<IFeedConsumption[]>>({
+		method: "get",
+		url: "/feed-consumptions",
+		urlParams: {
+			flockId: filters?.flockId,
+			feedTypeId: filters?.feedTypeId,
+			from: filters?.from,
+			to: filters?.to,
+			include: filters?.include,
+			page,
+			limit,
+		},
+	});
+
+export const getFeedConsumptionById = ({
+	feedConsumptionId,
+}: {
+	feedConsumptionId: string;
+}) =>
+	axiosHelper<IResponse<IFeedConsumption>>({
+		method: "get",
+		url: `/feed-consumptions/${feedConsumptionId}`,
+	});
+
+export const createFeedConsumption = ({
+	payload,
+}: {
+	payload: ICreateFeedConsumptionPayload;
+}) =>
+	axiosHelper<IResponse<IFeedConsumption>>({
+		method: "post",
+		url: "/feed-consumptions",
+		data: payload,
+	});
+
+export const deleteFeedConsumptionById = ({
+	feedConsumptionId,
+}: {
+	feedConsumptionId: string;
+}) =>
+	axiosHelper<IResponse<null>>({
+		method: "delete",
+		url: `/feed-consumptions/${feedConsumptionId}`,
+	});

--- a/src/features/feed-consumption/api/feed-consumption-queries.ts
+++ b/src/features/feed-consumption/api/feed-consumption-queries.ts
@@ -1,0 +1,175 @@
+import {
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import i18next from "i18next";
+import {
+	createFeedConsumption,
+	deleteFeedConsumptionById,
+	getFeedConsumptionById,
+	getFeedConsumptions,
+} from "@/features/feed-consumption/api/feed-consumption-api";
+import type {
+	ICreateFeedConsumptionPayload,
+	IFeedConsumptionListFilters,
+} from "@/features/feed-consumption/types/feed-consumption-types";
+import { feedLotQueryKeys } from "@/features/feed-lot/api/feed-lot-queries";
+
+const DEFAULT_LIST_PAGE_SIZE = 20;
+
+const normalizeFilters = (
+	filters?: Partial<IFeedConsumptionListFilters>,
+): string[] => [
+	filters?.flockId ?? "",
+	filters?.feedTypeId ?? "",
+	filters?.from ?? "",
+	filters?.to ?? "",
+	filters?.include ?? "",
+];
+
+export const feedConsumptionQueryKeys = {
+	all: ["feed-consumption"] as const,
+	farm: (farmId: string) =>
+		[...feedConsumptionQueryKeys.all, "farm", farmId] as const,
+	feedConsumptionList: (
+		farmId: string,
+		filters?: Partial<IFeedConsumptionListFilters>,
+	) =>
+		[
+			...feedConsumptionQueryKeys.farm(farmId),
+			"list",
+			normalizeFilters(filters),
+		] as const,
+	feedConsumptionListPage: (
+		farmId: string,
+		filters: Partial<IFeedConsumptionListFilters> | undefined,
+		limit: number,
+	) =>
+		[
+			...feedConsumptionQueryKeys.feedConsumptionList(farmId, filters),
+			"page",
+			limit,
+		] as const,
+	feedConsumptionById: (feedConsumptionId: string) =>
+		[...feedConsumptionQueryKeys.all, "byId", feedConsumptionId] as const,
+};
+
+export const useGetFeedConsumptions = ({
+	farmId,
+	filters,
+}: {
+	farmId: string;
+	filters?: Partial<IFeedConsumptionListFilters>;
+}) =>
+	useQuery({
+		queryKey: feedConsumptionQueryKeys.feedConsumptionList(farmId, filters),
+		queryFn: () => getFeedConsumptions({ filters, page: 1, limit: 100 }),
+		select: (data) => data.data,
+		enabled: !!farmId,
+	});
+
+export const useGetInfiniteFeedConsumptions = ({
+	farmId,
+	filters,
+	limit = DEFAULT_LIST_PAGE_SIZE,
+}: {
+	farmId: string;
+	filters?: Partial<IFeedConsumptionListFilters>;
+	limit?: number;
+}) =>
+	useInfiniteQuery({
+		queryKey: feedConsumptionQueryKeys.feedConsumptionListPage(
+			farmId,
+			filters,
+			limit,
+		),
+		queryFn: ({ pageParam }) =>
+			getFeedConsumptions({ filters, page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) => {
+			const pagination = lastPage.meta?.pagination;
+			if (!pagination) {
+				return undefined;
+			}
+
+			return pagination.page < pagination.totalPages
+				? pagination.page + 1
+				: undefined;
+		},
+		select: (data) => {
+			const items = data.pages.flatMap((page) => page.data);
+			const latestPagination = data.pages.at(-1)?.meta?.pagination;
+
+			return {
+				items,
+				total: latestPagination?.total ?? items.length,
+				totalPages: latestPagination?.totalPages ?? 1,
+			};
+		},
+		enabled: !!farmId,
+	});
+
+export const useGetFeedConsumptionById = (feedConsumptionId: string) =>
+	useQuery({
+		queryKey: feedConsumptionQueryKeys.feedConsumptionById(feedConsumptionId),
+		queryFn: () => getFeedConsumptionById({ feedConsumptionId }),
+		select: (data) => data.data,
+		enabled: !!feedConsumptionId,
+	});
+
+export const useCreateFeedConsumption = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			payload,
+		}: {
+			payload: ICreateFeedConsumptionPayload;
+			farmId: string;
+		}) => createFeedConsumption({ payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(i18next.t("feedConsumptions:toast.createSuccess"));
+			await Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: feedConsumptionQueryKeys.farm(farmId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: feedLotQueryKeys.farm(farmId),
+				}),
+			]);
+		},
+	});
+};
+
+export const useDeleteFeedConsumptionById = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			feedConsumptionId,
+		}: {
+			feedConsumptionId: string;
+			farmId: string;
+		}) => deleteFeedConsumptionById({ feedConsumptionId }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(i18next.t("feedConsumptions:toast.deleteSuccess"));
+			await Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: feedConsumptionQueryKeys.farm(farmId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: feedLotQueryKeys.farm(farmId),
+				}),
+			]);
+		},
+	});
+};

--- a/src/features/feed-consumption/types/feed-consumption-types.ts
+++ b/src/features/feed-consumption/types/feed-consumption-types.ts
@@ -1,0 +1,48 @@
+export const feedConsumptionReasons = [
+	"feeding",
+	"waste",
+	"transfer",
+	"adjustment",
+] as const;
+
+export type FeedConsumptionReason = (typeof feedConsumptionReasons)[number];
+
+export interface IFeedConsumptionLot {
+	id: string;
+	lotId: string;
+	qtyDrawn: number;
+	unitPriceSnapshot: number;
+}
+
+export interface IFeedConsumption {
+	id: string;
+	farmId: string;
+	flockId: string | null;
+	feedTypeId: string;
+	consumedAt: string;
+	qty: number;
+	reason: FeedConsumptionReason;
+	notes: string | null;
+	createdBy: string;
+	totalCost: number;
+	lots: IFeedConsumptionLot[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface IFeedConsumptionListFilters {
+	flockId?: string;
+	feedTypeId?: string;
+	from?: string;
+	to?: string;
+	include?: "lots";
+}
+
+export interface ICreateFeedConsumptionPayload {
+	flockId: string | null;
+	feedTypeId: string;
+	consumedAt: string;
+	qty: number;
+	reason: FeedConsumptionReason;
+	notes?: string;
+}

--- a/src/features/feed-lot/api/feed-lot-api.ts
+++ b/src/features/feed-lot/api/feed-lot-api.ts
@@ -1,0 +1,64 @@
+import { axiosHelper } from "@/lib/axios/axios-helper";
+import type { IResponse } from "@/lib/axios";
+import type {
+	ICreateFeedLotPayload,
+	IFeedLot,
+	IFeedLotListFilters,
+	IUpdateFeedLotPayload,
+} from "@/features/feed-lot/types/feed-lot-types";
+
+export const getFeedLots = ({
+	filters,
+	page,
+	limit,
+}: {
+	filters?: Partial<IFeedLotListFilters>;
+	page?: number;
+	limit?: number;
+}) =>
+	axiosHelper<IResponse<IFeedLot[]>>({
+		method: "get",
+		url: "/feed-lots",
+		urlParams: {
+			feedTypeId: filters?.feedTypeId,
+			hasStock: filters?.hasStock,
+			page,
+			limit,
+		},
+	});
+
+export const getFeedLotById = ({ feedLotId }: { feedLotId: string }) =>
+	axiosHelper<IResponse<IFeedLot>>({
+		method: "get",
+		url: `/feed-lots/${feedLotId}`,
+	});
+
+export const createFeedLot = ({
+	payload,
+}: {
+	payload: ICreateFeedLotPayload;
+}) =>
+	axiosHelper<IResponse<IFeedLot>>({
+		method: "post",
+		url: "/feed-lots",
+		data: payload,
+	});
+
+export const updateFeedLotById = ({
+	feedLotId,
+	payload,
+}: {
+	feedLotId: string;
+	payload: IUpdateFeedLotPayload;
+}) =>
+	axiosHelper<IResponse<IFeedLot>>({
+		method: "put",
+		url: `/feed-lots/${feedLotId}`,
+		data: payload,
+	});
+
+export const deleteFeedLotById = ({ feedLotId }: { feedLotId: string }) =>
+	axiosHelper<IResponse<null>>({
+		method: "delete",
+		url: `/feed-lots/${feedLotId}`,
+	});

--- a/src/features/feed-lot/api/feed-lot-queries.ts
+++ b/src/features/feed-lot/api/feed-lot-queries.ts
@@ -1,0 +1,172 @@
+import {
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import i18next from "i18next";
+import {
+	createFeedLot,
+	deleteFeedLotById,
+	getFeedLotById,
+	getFeedLots,
+	updateFeedLotById,
+} from "@/features/feed-lot/api/feed-lot-api";
+import type {
+	ICreateFeedLotPayload,
+	IFeedLotListFilters,
+	IUpdateFeedLotPayload,
+} from "@/features/feed-lot/types/feed-lot-types";
+
+const DEFAULT_LIST_PAGE_SIZE = 20;
+
+const normalizeFilters = (filters?: Partial<IFeedLotListFilters>): string[] => [
+	filters?.feedTypeId ?? "",
+	filters?.hasStock !== undefined ? String(filters.hasStock) : "",
+];
+
+export const feedLotQueryKeys = {
+	all: ["feed-lot"] as const,
+	farm: (farmId: string) => [...feedLotQueryKeys.all, "farm", farmId] as const,
+	feedLotList: (farmId: string, filters?: Partial<IFeedLotListFilters>) =>
+		[
+			...feedLotQueryKeys.farm(farmId),
+			"list",
+			normalizeFilters(filters),
+		] as const,
+	feedLotListPage: (
+		farmId: string,
+		filters: Partial<IFeedLotListFilters> | undefined,
+		limit: number,
+	) =>
+		[...feedLotQueryKeys.feedLotList(farmId, filters), "page", limit] as const,
+	feedLotById: (feedLotId: string) =>
+		[...feedLotQueryKeys.all, "byId", feedLotId] as const,
+};
+
+export const useGetFeedLots = ({
+	farmId,
+	filters,
+}: {
+	farmId: string;
+	filters?: Partial<IFeedLotListFilters>;
+}) =>
+	useQuery({
+		queryKey: feedLotQueryKeys.feedLotList(farmId, filters),
+		queryFn: () => getFeedLots({ filters, page: 1, limit: 100 }),
+		select: (data) => data.data,
+		enabled: !!farmId,
+	});
+
+export const useGetInfiniteFeedLots = ({
+	farmId,
+	filters,
+	limit = DEFAULT_LIST_PAGE_SIZE,
+}: {
+	farmId: string;
+	filters?: Partial<IFeedLotListFilters>;
+	limit?: number;
+}) =>
+	useInfiniteQuery({
+		queryKey: feedLotQueryKeys.feedLotListPage(farmId, filters, limit),
+		queryFn: ({ pageParam }) =>
+			getFeedLots({ filters, page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) => {
+			const pagination = lastPage.meta?.pagination;
+			if (!pagination) {
+				return undefined;
+			}
+
+			return pagination.page < pagination.totalPages
+				? pagination.page + 1
+				: undefined;
+		},
+		select: (data) => {
+			const items = data.pages.flatMap((page) => page.data);
+			const latestPagination = data.pages.at(-1)?.meta?.pagination;
+
+			return {
+				items,
+				total: latestPagination?.total ?? items.length,
+				totalPages: latestPagination?.totalPages ?? 1,
+			};
+		},
+		enabled: !!farmId,
+	});
+
+export const useGetFeedLotById = (feedLotId: string) =>
+	useQuery({
+		queryKey: feedLotQueryKeys.feedLotById(feedLotId),
+		queryFn: () => getFeedLotById({ feedLotId }),
+		select: (data) => data.data,
+		enabled: !!feedLotId,
+	});
+
+export const useCreateFeedLot = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			payload,
+		}: {
+			payload: ICreateFeedLotPayload;
+			farmId: string;
+		}) => createFeedLot({ payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(i18next.t("feedLots:toast.createSuccess"));
+			await queryClient.invalidateQueries({
+				queryKey: feedLotQueryKeys.farm(farmId),
+			});
+		},
+	});
+};
+
+export const useUpdateFeedLotById = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			feedLotId,
+			payload,
+		}: {
+			feedLotId: string;
+			payload: IUpdateFeedLotPayload;
+			farmId: string;
+		}) => updateFeedLotById({ feedLotId, payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId, feedLotId }) => {
+			toast.success(i18next.t("feedLots:toast.updateSuccess"));
+			await queryClient.invalidateQueries({
+				queryKey: feedLotQueryKeys.farm(farmId),
+			});
+			await queryClient.invalidateQueries({
+				queryKey: feedLotQueryKeys.feedLotById(feedLotId),
+			});
+		},
+	});
+};
+
+export const useDeleteFeedLotById = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ feedLotId }: { feedLotId: string; farmId: string }) =>
+			deleteFeedLotById({ feedLotId }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(i18next.t("feedLots:toast.deleteSuccess"));
+			await queryClient.invalidateQueries({
+				queryKey: feedLotQueryKeys.farm(farmId),
+			});
+		},
+	});
+};

--- a/src/features/feed-lot/types/feed-lot-types.ts
+++ b/src/features/feed-lot/types/feed-lot-types.ts
@@ -1,0 +1,35 @@
+export interface IFeedLot {
+	id: string;
+	farmId: string;
+	feedTypeId: string;
+	qtyPurchased: number;
+	qtyRemaining: number;
+	unitPrice: number;
+	purchasedAt: string;
+	supplier: string | null;
+	notes: string | null;
+	createdBy: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface IFeedLotListFilters {
+	feedTypeId?: string;
+	hasStock?: boolean;
+}
+
+export interface ICreateFeedLotPayload {
+	feedTypeId: string;
+	qtyPurchased: number;
+	unitPrice: number;
+	purchasedAt: string;
+	supplier?: string;
+	notes?: string;
+}
+
+export interface IUpdateFeedLotPayload {
+	unitPrice?: number;
+	purchasedAt?: string;
+	supplier?: string;
+	notes?: string;
+}

--- a/src/features/feed-report/api/feed-report-api.ts
+++ b/src/features/feed-report/api/feed-report-api.ts
@@ -1,0 +1,31 @@
+import { axiosHelper } from "@/lib/axios/axios-helper";
+import type { IResponse } from "@/lib/axios";
+import type {
+	IFeedCostByFlockResponse,
+	IFeedCostByLot,
+} from "@/features/feed-report/types/feed-report-types";
+
+export const getFeedCostByFlock = ({
+	filters,
+}: {
+	filters?: {
+		from?: string;
+		to?: string;
+		flockId?: string;
+	};
+}) =>
+	axiosHelper<IResponse<IFeedCostByFlockResponse>>({
+		method: "get",
+		url: "/feed-reports/cost-by-flock",
+		urlParams: {
+			from: filters?.from,
+			to: filters?.to,
+			flockId: filters?.flockId,
+		},
+	});
+
+export const getFeedCostByLot = ({ lotId }: { lotId: string }) =>
+	axiosHelper<IResponse<IFeedCostByLot>>({
+		method: "get",
+		url: `/feed-reports/cost-by-lot/${lotId}`,
+	});

--- a/src/features/feed-report/api/feed-report-queries.ts
+++ b/src/features/feed-report/api/feed-report-queries.ts
@@ -1,0 +1,134 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	getFeedCostByFlock,
+	getFeedCostByLot,
+} from "@/features/feed-report/api/feed-report-api";
+import type {
+	IFeedCostByFlockResponse,
+	IFeedCostByLot,
+} from "@/features/feed-report/types/feed-report-types";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+const toNumber = (value: unknown): number =>
+	typeof value === "number"
+		? value
+		: typeof value === "string"
+			? Number(value)
+			: 0;
+
+// Normalizer for cost-by-flock: handles the response envelope and ensures array
+const normalizeFeedCostByFlockResponse = (
+	value: unknown,
+): IFeedCostByFlockResponse => {
+	if (isRecord(value)) {
+		const flocks = Array.isArray(value.flocks) ? value.flocks : [];
+		return {
+			from: typeof value.from === "string" ? value.from : null,
+			to: typeof value.to === "string" ? value.to : null,
+			flocks: flocks.map((flock) => {
+				if (!isRecord(flock))
+					return { flockId: null, totalQty: 0, totalCost: 0, byFeedType: [] };
+				const byFeedType = Array.isArray(flock.byFeedType)
+					? flock.byFeedType.map((ft) => ({
+							feedTypeId:
+								isRecord(ft) && typeof ft.feedTypeId === "string"
+									? ft.feedTypeId
+									: "",
+							totalQty: isRecord(ft) ? toNumber(ft.totalQty) : 0,
+							totalCost: isRecord(ft) ? toNumber(ft.totalCost) : 0,
+						}))
+					: [];
+				return {
+					flockId: typeof flock.flockId === "string" ? flock.flockId : null,
+					totalQty: toNumber(flock.totalQty),
+					totalCost: toNumber(flock.totalCost),
+					byFeedType,
+				};
+			}),
+		};
+	}
+	return { from: null, to: null, flocks: [] };
+};
+
+// Normalizer for cost-by-lot: handles the response envelope
+const normalizeFeedCostByLot = (value: unknown): IFeedCostByLot | undefined => {
+	if (!isRecord(value)) return undefined;
+
+	const byFlock = Array.isArray(value.byFlock)
+		? value.byFlock.map((flock) => ({
+				flockId:
+					isRecord(flock) && typeof flock.flockId === "string"
+						? flock.flockId
+						: null,
+				totalQty: isRecord(flock) ? toNumber(flock.totalQty) : 0,
+				totalCost: isRecord(flock) ? toNumber(flock.totalCost) : 0,
+			}))
+		: [];
+
+	return {
+		lotId: typeof value.lotId === "string" ? value.lotId : "",
+		feedTypeId: typeof value.feedTypeId === "string" ? value.feedTypeId : "",
+		qtyPurchased: toNumber(value.qtyPurchased),
+		qtyRemaining: toNumber(value.qtyRemaining),
+		qtyDrawn: toNumber(value.qtyDrawn),
+		totalCost: toNumber(value.totalCost),
+		byFlock,
+	};
+};
+
+export const feedReportQueryKeys = {
+	all: ["feed-report"] as const,
+	farm: (farmId: string) =>
+		[...feedReportQueryKeys.all, "farm", farmId] as const,
+	costByFlock: (
+		farmId: string,
+		filters?: {
+			from?: string;
+			to?: string;
+			flockId?: string;
+		},
+	) =>
+		[
+			...feedReportQueryKeys.farm(farmId),
+			"cost-by-flock",
+			filters?.from ?? "",
+			filters?.to ?? "",
+			filters?.flockId ?? "",
+		] as const,
+	costByLot: (farmId: string, lotId: string) =>
+		[...feedReportQueryKeys.farm(farmId), "cost-by-lot", lotId] as const,
+};
+
+export const useGetFeedCostByFlock = ({
+	farmId,
+	filters,
+}: {
+	farmId: string;
+	filters?: {
+		from?: string;
+		to?: string;
+		flockId?: string;
+	};
+}) =>
+	useQuery({
+		queryKey: feedReportQueryKeys.costByFlock(farmId, filters),
+		queryFn: () => getFeedCostByFlock({ filters }),
+		select: (data) => normalizeFeedCostByFlockResponse(data.data),
+		enabled: !!farmId,
+	});
+
+export const useGetFeedCostByLot = ({
+	farmId,
+	lotId,
+}: {
+	farmId: string;
+	lotId?: string;
+}) =>
+	useQuery({
+		queryKey: feedReportQueryKeys.costByLot(farmId, lotId ?? ""),
+		queryFn: () => getFeedCostByLot({ lotId: lotId! }),
+		select: (data) => normalizeFeedCostByLot(data.data),
+		enabled: !!farmId && !!lotId,
+	});

--- a/src/features/feed-report/types/feed-report-types.ts
+++ b/src/features/feed-report/types/feed-report-types.ts
@@ -1,0 +1,36 @@
+// By-Flock Report - per-feed-type breakdown
+export interface IFeedCostByFeedType {
+	feedTypeId: string;
+	totalQty: number;
+	totalCost: number;
+}
+
+export interface IFeedCostByFlockRow {
+	flockId: string | null; // null for waste/transfers without flock attribution
+	totalQty: number;
+	totalCost: number;
+	byFeedType: IFeedCostByFeedType[];
+}
+
+export interface IFeedCostByFlockResponse {
+	from: string | null; // ISO date or null
+	to: string | null; // ISO date or null
+	flocks: IFeedCostByFlockRow[];
+}
+
+// By-Lot Report - consumption breakdown by flock
+export interface IFeedCostByFlockDetail {
+	flockId: string | null; // null for waste/transfers
+	totalQty: number;
+	totalCost: number;
+}
+
+export interface IFeedCostByLot {
+	lotId: string;
+	feedTypeId: string;
+	qtyPurchased: number;
+	qtyRemaining: number;
+	qtyDrawn: number;
+	totalCost: number;
+	byFlock: IFeedCostByFlockDetail[];
+}

--- a/src/features/feed-type/api/feed-type-api.ts
+++ b/src/features/feed-type/api/feed-type-api.ts
@@ -1,0 +1,56 @@
+import { axiosHelper } from "@/lib/axios/axios-helper";
+import type { IResponse } from "@/lib/axios";
+import type {
+	ICreateFeedTypePayload,
+	IFeedType,
+	IUpdateFeedTypePayload,
+} from "@/features/feed-type/types/feed-type-types";
+
+export const getFeedTypes = ({
+	page,
+	limit,
+}: {
+	page?: number;
+	limit?: number;
+}) =>
+	axiosHelper<IResponse<IFeedType[]>>({
+		method: "get",
+		url: "/feed-types",
+		urlParams: { page, limit },
+	});
+
+export const getFeedTypeById = ({ feedTypeId }: { feedTypeId: string }) =>
+	axiosHelper<IResponse<IFeedType>>({
+		method: "get",
+		url: `/feed-types/${feedTypeId}`,
+	});
+
+export const createFeedType = ({
+	payload,
+}: {
+	payload: ICreateFeedTypePayload;
+}) =>
+	axiosHelper<IResponse<IFeedType>>({
+		method: "post",
+		url: "/feed-types",
+		data: payload,
+	});
+
+export const updateFeedTypeById = ({
+	feedTypeId,
+	payload,
+}: {
+	feedTypeId: string;
+	payload: IUpdateFeedTypePayload;
+}) =>
+	axiosHelper<IResponse<IFeedType>>({
+		method: "put",
+		url: `/feed-types/${feedTypeId}`,
+		data: payload,
+	});
+
+export const deleteFeedTypeById = ({ feedTypeId }: { feedTypeId: string }) =>
+	axiosHelper<IResponse<null>>({
+		method: "delete",
+		url: `/feed-types/${feedTypeId}`,
+	});

--- a/src/features/feed-type/api/feed-type-queries.ts
+++ b/src/features/feed-type/api/feed-type-queries.ts
@@ -1,0 +1,155 @@
+import {
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import i18next from "i18next";
+import {
+	createFeedType,
+	deleteFeedTypeById,
+	getFeedTypeById,
+	getFeedTypes,
+	updateFeedTypeById,
+} from "@/features/feed-type/api/feed-type-api";
+import type {
+	ICreateFeedTypePayload,
+	IUpdateFeedTypePayload,
+} from "@/features/feed-type/types/feed-type-types";
+
+const DEFAULT_LIST_PAGE_SIZE = 20;
+
+export const feedTypeQueryKeys = {
+	all: ["feed-type"] as const,
+	farm: (farmId: string) => [...feedTypeQueryKeys.all, "farm", farmId] as const,
+	feedTypeList: (farmId: string) =>
+		[...feedTypeQueryKeys.farm(farmId), "list"] as const,
+	feedTypeListPage: (farmId: string, limit: number) =>
+		[...feedTypeQueryKeys.feedTypeList(farmId), "page", limit] as const,
+	feedTypeById: (feedTypeId: string) =>
+		[...feedTypeQueryKeys.all, "byId", feedTypeId] as const,
+};
+
+export const useGetFeedTypes = ({
+	farmId,
+	limit,
+}: {
+	farmId: string;
+	limit?: number;
+}) =>
+	useQuery({
+		queryKey: feedTypeQueryKeys.feedTypeList(farmId),
+		queryFn: () => getFeedTypes({ page: 1, limit: limit ?? 100 }),
+		select: (data) => data.data,
+		enabled: !!farmId,
+	});
+
+export const useGetInfiniteFeedTypes = ({
+	farmId,
+	limit = DEFAULT_LIST_PAGE_SIZE,
+}: {
+	farmId: string;
+	limit?: number;
+}) =>
+	useInfiniteQuery({
+		queryKey: feedTypeQueryKeys.feedTypeListPage(farmId, limit),
+		queryFn: ({ pageParam }) => getFeedTypes({ page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) => {
+			const pagination = lastPage.meta?.pagination;
+			if (!pagination) {
+				return undefined;
+			}
+
+			return pagination.page < pagination.totalPages
+				? pagination.page + 1
+				: undefined;
+		},
+		select: (data) => {
+			const items = data.pages.flatMap((page) => page.data);
+			const latestPagination = data.pages.at(-1)?.meta?.pagination;
+
+			return {
+				items,
+				total: latestPagination?.total ?? items.length,
+				totalPages: latestPagination?.totalPages ?? 1,
+			};
+		},
+		enabled: !!farmId,
+	});
+
+export const useGetFeedTypeById = (feedTypeId: string) =>
+	useQuery({
+		queryKey: feedTypeQueryKeys.feedTypeById(feedTypeId),
+		queryFn: () => getFeedTypeById({ feedTypeId }),
+		select: (data) => data.data,
+		enabled: !!feedTypeId,
+	});
+
+export const useCreateFeedType = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			payload,
+		}: {
+			payload: ICreateFeedTypePayload;
+			farmId: string;
+		}) => createFeedType({ payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(i18next.t("feedTypes:toast.createSuccess"));
+			await queryClient.invalidateQueries({
+				queryKey: feedTypeQueryKeys.farm(farmId),
+			});
+		},
+	});
+};
+
+export const useUpdateFeedTypeById = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			feedTypeId,
+			payload,
+		}: {
+			feedTypeId: string;
+			payload: IUpdateFeedTypePayload;
+			farmId: string;
+		}) => updateFeedTypeById({ feedTypeId, payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId, feedTypeId }) => {
+			toast.success(i18next.t("feedTypes:toast.updateSuccess"));
+			await queryClient.invalidateQueries({
+				queryKey: feedTypeQueryKeys.farm(farmId),
+			});
+			await queryClient.invalidateQueries({
+				queryKey: feedTypeQueryKeys.feedTypeById(feedTypeId),
+			});
+		},
+	});
+};
+
+export const useDeleteFeedTypeById = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ feedTypeId }: { feedTypeId: string; farmId: string }) =>
+			deleteFeedTypeById({ feedTypeId }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(i18next.t("feedTypes:toast.deleteSuccess"));
+			await queryClient.invalidateQueries({
+				queryKey: feedTypeQueryKeys.farm(farmId),
+			});
+		},
+	});
+};

--- a/src/features/feed-type/types/feed-type-types.ts
+++ b/src/features/feed-type/types/feed-type-types.ts
@@ -1,0 +1,23 @@
+export interface IFeedType {
+	id: string;
+	farmId: string;
+	name: string;
+	notes: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface IFeedTypeListFilters {
+	page?: number;
+	limit?: number;
+}
+
+export interface ICreateFeedTypePayload {
+	name: string;
+	notes?: string;
+}
+
+export interface IUpdateFeedTypePayload {
+	name?: string;
+	notes?: string;
+}

--- a/src/features/feeding-schedule/api/feeding-schedule-api.ts
+++ b/src/features/feeding-schedule/api/feeding-schedule-api.ts
@@ -1,0 +1,66 @@
+import { axiosHelper } from "@/lib/axios/axios-helper";
+import type { IResponse } from "@/lib/axios";
+import type {
+	ICreateFeedingSchedulePayload,
+	IFeedingSchedule,
+	IFeedingScheduleListFilters,
+	IUpdateFeedingSchedulePayload,
+} from "@/features/feeding-schedule/types/feeding-schedule-types";
+
+export const getFeedingSchedules = ({
+	filters,
+	page,
+	limit,
+}: {
+	filters?: Partial<IFeedingScheduleListFilters>;
+	page?: number;
+	limit?: number;
+}) =>
+	axiosHelper<IResponse<IFeedingSchedule[]>>({
+		method: "get",
+		url: "/feeding-schedules",
+		urlParams: {
+			flockId: filters?.flockId,
+			feedTypeId: filters?.feedTypeId,
+			activeOnly:
+				typeof filters?.activeOnly === "boolean"
+					? String(filters.activeOnly)
+					: undefined,
+			page,
+			limit,
+		},
+	});
+
+export const createFeedingSchedule = ({
+	payload,
+}: {
+	payload: ICreateFeedingSchedulePayload;
+}) =>
+	axiosHelper<IResponse<IFeedingSchedule>>({
+		method: "post",
+		url: "/feeding-schedules",
+		data: payload,
+	});
+
+export const updateFeedingScheduleById = ({
+	feedingScheduleId,
+	payload,
+}: {
+	feedingScheduleId: string;
+	payload: IUpdateFeedingSchedulePayload;
+}) =>
+	axiosHelper<IResponse<IFeedingSchedule>>({
+		method: "put",
+		url: `/feeding-schedules/${feedingScheduleId}`,
+		data: payload,
+	});
+
+export const deleteFeedingScheduleById = ({
+	feedingScheduleId,
+}: {
+	feedingScheduleId: string;
+}) =>
+	axiosHelper<IResponse<null>>({
+		method: "delete",
+		url: `/feeding-schedules/${feedingScheduleId}`,
+	});

--- a/src/features/feeding-schedule/api/feeding-schedule-queries.ts
+++ b/src/features/feeding-schedule/api/feeding-schedule-queries.ts
@@ -1,0 +1,125 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import i18next from "i18next";
+import {
+	createFeedingSchedule,
+	deleteFeedingScheduleById,
+	getFeedingSchedules,
+	updateFeedingScheduleById,
+} from "@/features/feeding-schedule/api/feeding-schedule-api";
+import type {
+	ICreateFeedingSchedulePayload,
+	IFeedingScheduleListFilters,
+	IUpdateFeedingSchedulePayload,
+} from "@/features/feeding-schedule/types/feeding-schedule-types";
+
+const normalizeFilters = (
+	filters?: Partial<IFeedingScheduleListFilters>,
+): string[] => [
+	filters?.flockId ?? "",
+	filters?.feedTypeId ?? "",
+	typeof filters?.activeOnly === "boolean" ? String(filters.activeOnly) : "",
+];
+
+export const feedingScheduleQueryKeys = {
+	all: ["feeding-schedule"] as const,
+	farm: (farmId: string) =>
+		[...feedingScheduleQueryKeys.all, "farm", farmId] as const,
+	feedingScheduleList: (
+		farmId: string,
+		filters?: Partial<IFeedingScheduleListFilters>,
+	) =>
+		[
+			...feedingScheduleQueryKeys.farm(farmId),
+			"list",
+			normalizeFilters(filters),
+		] as const,
+};
+
+export const useGetFeedingSchedules = ({
+	farmId,
+	filters,
+}: {
+	farmId: string;
+	filters?: Partial<IFeedingScheduleListFilters>;
+}) =>
+	useQuery({
+		queryKey: feedingScheduleQueryKeys.feedingScheduleList(farmId, filters),
+		queryFn: () => getFeedingSchedules({ filters, page: 1, limit: 100 }),
+		select: (data) => data.data,
+		enabled: !!farmId,
+	});
+
+export const useCreateFeedingSchedule = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			payload,
+		}: {
+			payload: ICreateFeedingSchedulePayload;
+			farmId: string;
+		}) => createFeedingSchedule({ payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(
+				i18next.t("inventory:feedingSchedules.toast.createSuccess"),
+			);
+			await queryClient.invalidateQueries({
+				queryKey: feedingScheduleQueryKeys.farm(farmId),
+			});
+		},
+	});
+};
+
+export const useUpdateFeedingScheduleById = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			feedingScheduleId,
+			payload,
+		}: {
+			feedingScheduleId: string;
+			payload: IUpdateFeedingSchedulePayload;
+			farmId: string;
+		}) => updateFeedingScheduleById({ feedingScheduleId, payload }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(
+				i18next.t("inventory:feedingSchedules.toast.updateSuccess"),
+			);
+			await queryClient.invalidateQueries({
+				queryKey: feedingScheduleQueryKeys.farm(farmId),
+			});
+		},
+	});
+};
+
+export const useDeleteFeedingScheduleById = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			feedingScheduleId,
+		}: {
+			feedingScheduleId: string;
+			farmId: string;
+		}) => deleteFeedingScheduleById({ feedingScheduleId }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: async (_, { farmId }) => {
+			toast.success(
+				i18next.t("inventory:feedingSchedules.toast.deleteSuccess"),
+			);
+			await queryClient.invalidateQueries({
+				queryKey: feedingScheduleQueryKeys.farm(farmId),
+			});
+		},
+	});
+};

--- a/src/features/feeding-schedule/types/feeding-schedule-types.ts
+++ b/src/features/feeding-schedule/types/feeding-schedule-types.ts
@@ -1,0 +1,39 @@
+export interface IFeedingSchedule {
+	id: string;
+	farmId: string;
+	flockId: string;
+	feedTypeId: string;
+	qtyPerDay: number;
+	activeFrom: string; // ISO date YYYY-MM-DD
+	activeTo: string | null; // ISO date YYYY-MM-DD or null if still active
+	createdAt: string;
+	updatedAt: string;
+	flock?: {
+		id: string;
+		name: string;
+	};
+	feedType?: {
+		id: string;
+		name: string;
+	};
+}
+
+export interface IFeedingScheduleListFilters {
+	flockId?: string;
+	feedTypeId?: string;
+	activeOnly?: boolean;
+}
+
+export interface ICreateFeedingSchedulePayload {
+	flockId: string;
+	feedTypeId: string;
+	qtyPerDay: number;
+	activeFrom: string; // ISO date YYYY-MM-DD
+	activeTo?: string | null; // Optional, omit or null if open-ended
+}
+
+export interface IUpdateFeedingSchedulePayload {
+	qtyPerDay?: number;
+	activeFrom?: string;
+	activeTo?: string | null;
+}

--- a/src/features/flock/api/flock-api.ts
+++ b/src/features/flock/api/flock-api.ts
@@ -19,6 +19,8 @@ import type {
 import i18next from "i18next";
 import { ApiRequestError } from "@/lib/axios/axios-helper";
 
+const MAX_FLOCK_EVENTS_LIMIT = 100;
+
 const getRequestLanguage = (): string => {
 	const normalizedLanguage = i18next.language.slice(0, 2);
 
@@ -137,15 +139,18 @@ export const getFlockEvents = ({
 	flockId: string;
 	page: number;
 	limit: number;
-}) =>
-	axiosHelper<IResponse<IFlockEvent[]>>({
+}) => {
+	const safeLimit = Math.min(limit, MAX_FLOCK_EVENTS_LIMIT);
+
+	return axiosHelper<IResponse<IFlockEvent[]>>({
 		method: "get",
 		url: `/flocks/${flockId}/events`,
 		urlParams: {
 			page: String(page),
-			limit: String(limit),
+			limit: String(safeLimit),
 		},
 	});
+};
 
 export const createFlockEvent = ({
 	flockId,

--- a/src/features/flock/api/flock-api.ts
+++ b/src/features/flock/api/flock-api.ts
@@ -1,8 +1,3 @@
-export const deleteFlockById = ({ flockId }: { flockId: string }) =>
-	axiosHelper<IResponse<{ message: string }>>({
-		method: "delete",
-		url: `/flocks/${flockId}`,
-	});
 import { axiosHelper } from "@/lib/axios/axios-helper";
 import type { IResponse } from "@/lib/axios";
 import type {
@@ -128,6 +123,25 @@ export const updateFlockById = ({
 	axiosHelper<IResponse<IFlock>>({
 		method: "put",
 		url: `/flocks/${flockId}`,
+		data: payload,
+	});
+
+export const deleteFlockById = ({ flockId }: { flockId: string }) =>
+	axiosHelper<IResponse<{ message: string }>>({
+		method: "delete",
+		url: `/flocks/${flockId}`,
+	});
+
+export const logTodaysFeeding = ({
+	flockId,
+	payload,
+}: {
+	flockId: string;
+	payload?: { date?: string };
+}) =>
+	axiosHelper<IResponse<{ message: string }>>({
+		method: "post",
+		url: `/flocks/${flockId}/log-todays-feeding`,
 		data: payload,
 	});
 

--- a/src/features/flock/api/flock-queries.ts
+++ b/src/features/flock/api/flock-queries.ts
@@ -1,36 +1,25 @@
-import { deleteFlockById } from "@/features/flock/api/flock-api";
-export const useDeleteFlockById = () => {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: ({ flockId }: { flockId: string }) =>
-			deleteFlockById({ flockId }),
-		onError: (error) => {
-			toast.error(error.message);
-		},
-		onSuccess: (_, variables) => {
-			toast.success(i18next.t("flocks:deleteDialog.success"));
-			if (variables && "farmId" in variables) {
-				void queryClient.invalidateQueries({
-					queryKey: [...flockQueryKeys.all, "list", variables.farmId],
-				});
-			}
-		},
-	});
-};
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { keepPreviousData } from "@tanstack/react-query";
 import {
 	createEggCollection,
 	createFlockEvent,
 	createFlock,
+	deleteFlockById,
 	deleteEggCollection,
 	getEggCollections,
 	getFlockById,
 	getFlockEvents,
 	getFlocks,
+	logTodaysFeeding,
 	updateEggCollection,
 	updateFlockById,
 } from "@/features/flock/api/flock-api";
+import { feedConsumptionQueryKeys } from "@/features/feed-consumption/api/feed-consumption-queries";
 import type {
 	ICreateEggCollectionPayload,
 	ICreateFlockPayload,
@@ -42,6 +31,23 @@ import type {
 import i18next from "i18next";
 import { toast } from "sonner";
 
+export const useDeleteFlockById = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: ({ flockId }: { flockId: string; farmId: string }) =>
+			deleteFlockById({ flockId }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: (_, { farmId }) => {
+			toast.success(i18next.t("flocks:deleteDialog.success"));
+			void queryClient.invalidateQueries({
+				queryKey: [...flockQueryKeys.all, "list", farmId],
+			});
+		},
+	});
+};
+
 const normalizeFilters = (filters?: Partial<IFlockListFilters>): string[] => {
 	return [
 		filters?.status ?? "",
@@ -49,6 +55,9 @@ const normalizeFilters = (filters?: Partial<IFlockListFilters>): string[] => {
 		filters?.speciesId ?? "",
 	];
 };
+
+const DEFAULT_EVENTS_PAGE_SIZE = 5;
+const DEFAULT_EGG_COLLECTIONS_PAGE_SIZE = 5;
 
 export const flockQueryKeys = {
 	all: ["flock"] as const,
@@ -241,6 +250,42 @@ export const useGetFlockEventsPage = ({
 		placeholderData: keepPreviousData,
 	});
 
+export const useGetInfiniteFlockEvents = ({
+	flockId,
+	limit = DEFAULT_EVENTS_PAGE_SIZE,
+}: {
+	flockId: string;
+	limit?: number;
+}) =>
+	useInfiniteQuery({
+		queryKey: [...flockQueryKeys.all, "events", flockId, "infinite", limit],
+		queryFn: ({ pageParam }) =>
+			getFlockEvents({ flockId, page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) => {
+			const pagination = lastPage.meta?.pagination;
+			if (!pagination) {
+				return undefined;
+			}
+
+			return pagination.page < pagination.totalPages
+				? pagination.page + 1
+				: undefined;
+		},
+		select: (data) => {
+			const items = data.pages.flatMap((page) => page.data);
+			const latestPagination =
+				data.pages[data.pages.length - 1]?.meta?.pagination;
+
+			return {
+				items,
+				total: latestPagination?.total ?? items.length,
+				totalPages: latestPagination?.totalPages ?? 1,
+			};
+		},
+		enabled: !!flockId,
+	});
+
 export const useGetEggCollectionsPage = ({
 	flockId,
 	page,
@@ -266,6 +311,48 @@ export const useGetEggCollectionsPage = ({
 		},
 		enabled: !!flockId,
 		placeholderData: keepPreviousData,
+	});
+
+export const useGetInfiniteEggCollections = ({
+	flockId,
+	limit = DEFAULT_EGG_COLLECTIONS_PAGE_SIZE,
+}: {
+	flockId: string;
+	limit?: number;
+}) =>
+	useInfiniteQuery({
+		queryKey: [
+			...flockQueryKeys.all,
+			"eggCollections",
+			flockId,
+			"infinite",
+			limit,
+		],
+		queryFn: ({ pageParam }) =>
+			getEggCollections({ flockId, page: pageParam, limit }),
+		initialPageParam: 1,
+		getNextPageParam: (lastPage) => {
+			const pagination = lastPage.meta?.pagination;
+			if (!pagination) {
+				return undefined;
+			}
+
+			return pagination.page < pagination.totalPages
+				? pagination.page + 1
+				: undefined;
+		},
+		select: (data) => {
+			const items = data.pages.flatMap((page) => page.data);
+			const latestPagination =
+				data.pages[data.pages.length - 1]?.meta?.pagination;
+
+			return {
+				items,
+				total: latestPagination?.total ?? items.length,
+				totalPages: latestPagination?.totalPages ?? 1,
+			};
+		},
+		enabled: !!flockId,
 	});
 
 export const useCreateEggCollection = () => {
@@ -337,6 +424,36 @@ export const useDeleteEggCollection = () => {
 			toast.success(i18next.t("flocks:detail.eggCollections.deleteSuccess"));
 			void queryClient.invalidateQueries({
 				queryKey: [...flockQueryKeys.all, "eggCollections", flockId],
+			});
+		},
+	});
+};
+
+export const useLogTodaysFeeding = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			flockId,
+			date,
+		}: {
+			flockId: string;
+			farmId: string;
+			date?: string;
+		}) => logTodaysFeeding({ flockId, payload: date ? { date } : undefined }),
+		onError: (error) => {
+			toast.error(error.message);
+		},
+		onSuccess: (_, { farmId, flockId }) => {
+			toast.success(i18next.t("flocks:detail.logToday.success"));
+			void queryClient.invalidateQueries({
+				queryKey: [...flockQueryKeys.all, "byId", flockId],
+			});
+			void queryClient.invalidateQueries({
+				queryKey: [...flockQueryKeys.all, "events", flockId],
+			});
+			void queryClient.invalidateQueries({
+				queryKey: feedConsumptionQueryKeys.farm(farmId),
 			});
 		},
 	});

--- a/src/features/flock/components/egg-collections-list.tsx
+++ b/src/features/flock/components/egg-collections-list.tsx
@@ -1,61 +1,18 @@
 import { DeleteEggCollectionDialog } from "@/features/flock/components/delete-egg-collection-dialog";
 import { RecordEggCollectionModal } from "@/features/flock/components/record-egg-collection-modal";
-import type {
-	IEggCollection,
-	IFlockEvent,
-} from "@/features/flock/types/flock-types";
+import type { IEggCollection } from "@/features/flock/types/flock-types";
 import { useTranslation } from "react-i18next";
 
 interface EggCollectionsListProps {
 	eggCollections: IEggCollection[];
 	flockId: string;
 	farmId: string;
-	flockInitialCount: number;
-	flockEventsForHistory: IFlockEvent[];
 }
-
-const getEventDelta = (event: IFlockEvent): number => {
-	switch (event.eventType) {
-		case "addition":
-			return event.count;
-		case "mortality":
-		case "sale":
-		case "cull":
-		case "transfer":
-			return -event.count;
-		default:
-			return 0;
-	}
-};
-
-const getFlockCountAtDate = ({
-	initialCount,
-	events,
-	date,
-}: {
-	initialCount: number;
-	events: IFlockEvent[];
-	date: string;
-}): number => {
-	const normalizedTargetDate = date.slice(0, 10);
-
-	const delta = events.reduce((sum, event) => {
-		if (event.date.slice(0, 10) > normalizedTargetDate) {
-			return sum;
-		}
-
-		return sum + getEventDelta(event);
-	}, 0);
-
-	return Math.max(0, initialCount + delta);
-};
 
 export const EggCollectionsList = ({
 	eggCollections,
 	flockId,
 	farmId,
-	flockInitialCount,
-	flockEventsForHistory,
 }: EggCollectionsListProps) => {
 	const { t } = useTranslation("flocks");
 
@@ -69,53 +26,41 @@ export const EggCollectionsList = ({
 
 	return (
 		<div className="space-y-2">
-			{eggCollections.map((eggCollection) => {
-				const flockCountAtCollection = getFlockCountAtDate({
-					initialCount: flockInitialCount,
-					events: flockEventsForHistory,
-					date: eggCollection.date,
-				});
-				const stableLayRate =
-					flockCountAtCollection > 0
-						? (eggCollection.totalEggs / flockCountAtCollection) * 100
-						: 0;
-
-				return (
-					<div
-						key={eggCollection.id}
-						className="rounded-card border p-3"
-					>
-						<div className="flex items-center justify-between gap-2">
-							<p className="font-medium">{eggCollection.date}</p>
-							<div className="flex items-center gap-1">
-								<p className="text-sm text-muted-foreground">
-									{t("detail.eggCollections.layRate", {
-										layRate: stableLayRate.toFixed(2),
-									})}
-								</p>
-								<RecordEggCollectionModal
-									mode="edit"
-									flockId={flockId}
-									farmId={farmId}
-									collection={eggCollection}
-								/>
-								<DeleteEggCollectionDialog
-									flockId={flockId}
-									farmId={farmId}
-									collectionId={eggCollection.id}
-								/>
-							</div>
+			{eggCollections.map((eggCollection) => (
+				<div
+					key={eggCollection.id}
+					className="rounded-card border p-3"
+				>
+					<div className="flex items-center justify-between gap-2">
+						<p className="font-medium">{eggCollection.date}</p>
+						<div className="flex items-center gap-1">
+							<p className="text-sm text-muted-foreground">
+								{t("detail.eggCollections.layRate", {
+									layRate: eggCollection.layRate?.toFixed(2) ?? "-",
+								})}
+							</p>
+							<RecordEggCollectionModal
+								mode="edit"
+								flockId={flockId}
+								farmId={farmId}
+								collection={eggCollection}
+							/>
+							<DeleteEggCollectionDialog
+								flockId={flockId}
+								farmId={farmId}
+								collectionId={eggCollection.id}
+							/>
 						</div>
-						<p className="text-sm">
-							{t("detail.eggCollections.totals", {
-								totalEggs: eggCollection.totalEggs,
-								usableEggs: eggCollection.usableEggs,
-								brokenEggs: eggCollection.brokenEggs,
-							})}
-						</p>
 					</div>
-				);
-			})}
+					<p className="text-sm">
+						{t("detail.eggCollections.totals", {
+							totalEggs: eggCollection.totalEggs,
+							usableEggs: eggCollection.usableEggs,
+							brokenEggs: eggCollection.brokenEggs,
+						})}
+					</p>
+				</div>
+			))}
 		</div>
 	);
 };

--- a/src/features/flock/components/flock-card.tsx
+++ b/src/features/flock/components/flock-card.tsx
@@ -43,14 +43,18 @@ export const FlockCard = ({ flock }: FlockCardProps) => {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const { mutate: deleteFlock, isPending: isDeleting } = useDeleteFlockById();
 	const navigate = useNavigate();
+	const { farmId } = useParams({ strict: false });
 	const handleDelete = () => {
+		if (!farmId) {
+			return;
+		}
+
 		deleteFlock(
-			{ flockId: flock.id },
+			{ flockId: flock.id, farmId },
 			{ onSuccess: () => setDeleteDialogOpen(false) },
 		);
 	};
 	const { t, i18n } = useTranslation("flocks");
-	const { farmId } = useParams({ strict: false });
 	const preferredLanguage = i18n.language.slice(0, 2) || "en";
 
 	const speciesName = getTranslationName(

--- a/src/features/flock/components/flock-events-list.tsx
+++ b/src/features/flock/components/flock-events-list.tsx
@@ -21,17 +21,25 @@ export const FlockEventsList = ({ events }: FlockEventsListProps) => {
 			{events.map((event) => (
 				<div
 					key={event.id}
-					className="rounded-card border p-3"
+					className="rounded-card border px-3 py-2"
 				>
-					<div className="flex items-center justify-between gap-2">
-						<p className="font-medium">{t(`eventType.${event.eventType}`)}</p>
-						<p className="text-sm text-muted-foreground">{event.date}</p>
+					<div className="flex items-start justify-between gap-3">
+						<div className="min-w-0 space-y-1">
+							<p className="text-sm font-semibold leading-tight">
+								{t(`eventType.${event.eventType}`)}
+							</p>
+							<p className="text-xs text-muted-foreground leading-tight">
+								{t("detail.events.count", { count: event.count })}
+							</p>
+						</div>
+						<p className="shrink-0 text-xs text-muted-foreground leading-tight">
+							{event.date}
+						</p>
 					</div>
-					<p className="text-sm">
-						{t("detail.events.count", { count: event.count })}
-					</p>
 					{event.reason && (
-						<p className="text-sm text-muted-foreground">{event.reason}</p>
+						<p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+							{event.reason}
+						</p>
 					)}
 				</div>
 			))}

--- a/src/features/inventory/components/feed-consumption-panel.tsx
+++ b/src/features/inventory/components/feed-consumption-panel.tsx
@@ -1,0 +1,342 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	feedConsumptionReasons,
+	type FeedConsumptionReason,
+} from "@/features/feed-consumption/types/feed-consumption-types";
+import {
+	useCreateFeedConsumption,
+	useDeleteFeedConsumptionById,
+	useGetInfiniteFeedConsumptions,
+} from "@/features/feed-consumption/api/feed-consumption-queries";
+import { useGetFeedTypes } from "@/features/feed-type/api/feed-type-queries";
+import { useGetFlocksPage } from "@/features/flock/api/flock-queries";
+import { useTranslation } from "react-i18next";
+
+interface FeedConsumptionPanelProps {
+	farmId: string;
+}
+
+export const FeedConsumptionPanel = ({ farmId }: FeedConsumptionPanelProps) => {
+	const { t } = useTranslation("inventory");
+	const [open, setOpen] = useState(false);
+	const [feedTypeId, setFeedTypeId] = useState<string>("");
+	const [flockId, setFlockId] = useState<string>("none");
+	const [consumedAt, setConsumedAt] = useState<string>("");
+	const [qty, setQty] = useState<string>("");
+	const [reason, setReason] = useState<FeedConsumptionReason>("feeding");
+	const [notes, setNotes] = useState<string>("");
+	const [deleteConsumptionId, setDeleteConsumptionId] = useState<string | null>(
+		null,
+	);
+	const loadMoreRef = useRef<HTMLDivElement | null>(null);
+	const filters = useMemo(() => ({ include: "lots" as const }), []);
+	const { data: feedTypes = [] } = useGetFeedTypes({ farmId });
+	const { data: flockData } = useGetFlocksPage({ farmId, page: 1, limit: 100 });
+	const flocks = flockData?.items ?? [];
+	const hasFeedTypes = feedTypes.length > 0;
+	const { data, isPending, hasNextPage, fetchNextPage, isFetchingNextPage } =
+		useGetInfiniteFeedConsumptions({
+			farmId,
+			filters,
+			limit: 5,
+		});
+	const consumptions = data?.items ?? [];
+
+	useEffect(() => {
+		const target = loadMoreRef.current;
+		if (!target || !hasNextPage) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const entry = entries[0];
+				if (!entry?.isIntersecting || isFetchingNextPage) {
+					return;
+				}
+
+				void fetchNextPage();
+			},
+			{ rootMargin: "200px" },
+		);
+
+		observer.observe(target);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [fetchNextPage, hasNextPage, isFetchingNextPage, consumptions.length]);
+	const { mutateAsync: createConsumption, isPending: isCreating } =
+		useCreateFeedConsumption();
+	const { mutateAsync: deleteConsumption, isPending: isDeleting } =
+		useDeleteFeedConsumptionById();
+
+	const handleCreate = async () => {
+		if (!feedTypeId || !qty || !consumedAt) {
+			return;
+		}
+
+		if (reason === "feeding" && flockId === "none") {
+			return;
+		}
+
+		await createConsumption({
+			farmId,
+			payload: {
+				feedTypeId,
+				flockId: flockId === "none" ? null : flockId,
+				consumedAt,
+				qty: Number(qty),
+				reason,
+				notes: notes.trim() || undefined,
+			},
+		});
+		setFeedTypeId("");
+		setFlockId("none");
+		setConsumedAt("");
+		setQty("");
+		setReason("feeding");
+		setNotes("");
+		setOpen(false);
+	};
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-center justify-between">
+				<CardTitle>{t("feedLog.title")}</CardTitle>
+				<Dialog
+					open={open}
+					onOpenChange={setOpen}
+				>
+					<DialogTrigger asChild>
+						<Button
+							size="sm"
+							disabled={!hasFeedTypes}
+						>
+							{t("feedLog.newButton")}
+						</Button>
+					</DialogTrigger>
+					<DialogContent className="max-h-[90vh] overflow-y-auto">
+						<DialogTitle>{t("feedLog.modal.title")}</DialogTitle>
+						<DialogDescription>
+							{t("feedLog.modal.description")}
+						</DialogDescription>
+						<div className="space-y-3">
+							<Label>{t("feedLog.modal.feedType")}</Label>
+							<Select
+								value={feedTypeId}
+								onValueChange={setFeedTypeId}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue
+										placeholder={t("feedLog.modal.feedTypePlaceholder")}
+									/>
+								</SelectTrigger>
+								<SelectContent>
+									{feedTypes.map((item) => (
+										<SelectItem
+											key={item.id}
+											value={item.id}
+										>
+											{item.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<Label>{t("feedLog.modal.reason")}</Label>
+							<Select
+								value={reason}
+								onValueChange={(value: FeedConsumptionReason) =>
+									setReason(value)
+								}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{feedConsumptionReasons.map((item) => (
+										<SelectItem
+											key={item}
+											value={item}
+										>
+											{t(`feedLog.reasonOptions.${item}`)}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<Label>{t("feedLog.modal.flock")}</Label>
+							<Select
+								value={flockId}
+								onValueChange={setFlockId}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="none">
+										{t("feedLog.modal.noFlock")}
+									</SelectItem>
+									{flocks.map((item) => (
+										<SelectItem
+											key={item.id}
+											value={item.id}
+										>
+											{item.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+								<div>
+									<Label>{t("feedLog.modal.quantity")}</Label>
+									<Input
+										type="number"
+										min="0"
+										step="0.01"
+										value={qty}
+										onChange={(event) => setQty(event.target.value)}
+									/>
+								</div>
+								<div>
+									<Label>{t("feedLog.modal.date")}</Label>
+									<Input
+										type="date"
+										value={consumedAt}
+										onChange={(event) => setConsumedAt(event.target.value)}
+									/>
+								</div>
+							</div>
+							<div>
+								<Label>{t("feedLog.modal.notes")}</Label>
+								<Textarea
+									value={notes}
+									onChange={(event) => setNotes(event.target.value)}
+								/>
+							</div>
+							<Button
+								className="w-full"
+								disabled={isCreating}
+								onClick={() => void handleCreate()}
+							>
+								{t("feedLog.modal.create")}
+							</Button>
+						</div>
+					</DialogContent>
+				</Dialog>
+			</CardHeader>
+			<CardContent>
+				{!hasFeedTypes ? (
+					<div className="mb-3 rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+						{t("feedLog.adminManagedNotice")}
+					</div>
+				) : null}
+				{isPending ? (
+					<p className="text-sm text-muted-foreground">
+						{t("feedLog.loading")}
+					</p>
+				) : consumptions.length === 0 ? (
+					<p className="text-sm text-muted-foreground">{t("feedLog.empty")}</p>
+				) : (
+					<div className="space-y-2">
+						{consumptions.map((item) => (
+							<div
+								key={item.id}
+								className="rounded-md border p-3 flex items-center justify-between gap-3"
+							>
+								<div className="text-sm">
+									<p className="font-medium">
+										{t("feedLog.itemTitle", {
+											qty: item.qty,
+											reason: t(`feedLog.reasonOptions.${item.reason}`),
+										})}
+									</p>
+									<p className="text-muted-foreground">
+										{t("feedLog.itemSubtitle", {
+											date: item.consumedAt,
+											cost: item.totalCost.toFixed(2),
+										})}
+									</p>
+								</div>
+								<Dialog
+									open={deleteConsumptionId === item.id}
+									onOpenChange={(open) =>
+										setDeleteConsumptionId(open ? item.id : null)
+									}
+								>
+									<DialogTrigger asChild>
+										<Button
+											variant="outline"
+											size="sm"
+											disabled={isDeleting}
+										>
+											{t("feedLog.delete")}
+										</Button>
+									</DialogTrigger>
+									<DialogContent className="max-w-sm">
+										<DialogTitle>{t("feedLog.deleteDialog.title")}</DialogTitle>
+										<DialogDescription>
+											{t("feedLog.deleteDialog.description")}
+										</DialogDescription>
+										<div className="flex justify-end gap-2">
+											<Button
+												variant="outline"
+												onClick={() => setDeleteConsumptionId(null)}
+												disabled={isDeleting}
+											>
+												{t("feedLog.deleteDialog.cancel")}
+											</Button>
+											<Button
+												variant="destructive"
+												disabled={isDeleting}
+												onClick={() =>
+													void deleteConsumption({
+														farmId,
+														feedConsumptionId: item.id,
+													}).then(() => {
+														setDeleteConsumptionId(null);
+													})
+												}
+											>
+												{t("feedLog.deleteDialog.confirm")}
+											</Button>
+										</div>
+									</DialogContent>
+								</Dialog>
+							</div>
+						))}
+						{hasNextPage ? (
+							<div
+								ref={loadMoreRef}
+								className="h-2"
+							/>
+						) : null}
+						{isFetchingNextPage ? (
+							<p className="text-sm text-muted-foreground">
+								{t("feedLog.loadingMore")}
+							</p>
+						) : null}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+};

--- a/src/features/inventory/components/feed-lot-panel.tsx
+++ b/src/features/inventory/components/feed-lot-panel.tsx
@@ -1,0 +1,364 @@
+import { Trash2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useGetFeedTypes } from "@/features/feed-type/api/feed-type-queries";
+import {
+	useCreateFeedLot,
+	useDeleteFeedLotById,
+	useGetInfiniteFeedLots,
+} from "@/features/feed-lot/api/feed-lot-queries";
+import { useTranslation } from "react-i18next";
+
+interface FeedLotPanelProps {
+	farmId: string;
+}
+
+export const FeedLotPanel = ({ farmId }: FeedLotPanelProps) => {
+	const { t } = useTranslation("inventory");
+	const [open, setOpen] = useState(false);
+	const [filterFeedTypeId, setFilterFeedTypeId] = useState<string>("all");
+	const [stockFilter, setStockFilter] = useState<"all" | "with_stock">(
+		"with_stock",
+	);
+	const [feedTypeId, setFeedTypeId] = useState<string>("");
+	const [qtyPurchased, setQtyPurchased] = useState<string>("");
+	const [unitPrice, setUnitPrice] = useState<string>("");
+	const [purchasedAt, setPurchasedAt] = useState<string>("");
+	const [supplier, setSupplier] = useState<string>("");
+	const [notes, setNotes] = useState<string>("");
+	const [deleteLotId, setDeleteLotId] = useState<string | null>(null);
+	const loadMoreRef = useRef<HTMLDivElement | null>(null);
+	const { data: feedTypes = [] } = useGetFeedTypes({ farmId });
+	const filters = useMemo(
+		() => ({
+			feedTypeId: filterFeedTypeId === "all" ? undefined : filterFeedTypeId,
+			hasStock: stockFilter === "with_stock" ? true : undefined,
+		}),
+		[filterFeedTypeId, stockFilter],
+	);
+	const { data, isPending, hasNextPage, fetchNextPage, isFetchingNextPage } =
+		useGetInfiniteFeedLots({
+			farmId,
+			filters,
+			limit: 5,
+		});
+	const feedLots = data?.items ?? [];
+
+	useEffect(() => {
+		const target = loadMoreRef.current;
+		if (!target || !hasNextPage) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const entry = entries[0];
+				if (!entry?.isIntersecting || isFetchingNextPage) {
+					return;
+				}
+
+				void fetchNextPage();
+			},
+			{ rootMargin: "200px" },
+		);
+
+		observer.observe(target);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [fetchNextPage, hasNextPage, isFetchingNextPage, feedLots.length]);
+	const hasFeedTypes = feedTypes.length > 0;
+	const { mutateAsync: createFeedLot, isPending: isCreating } =
+		useCreateFeedLot();
+	const { mutateAsync: deleteFeedLot, isPending: isDeleting } =
+		useDeleteFeedLotById();
+
+	const handleCreate = async () => {
+		if (!feedTypeId || !qtyPurchased || !unitPrice || !purchasedAt) {
+			return;
+		}
+
+		await createFeedLot({
+			farmId,
+			payload: {
+				feedTypeId,
+				qtyPurchased: Number(qtyPurchased),
+				unitPrice: Number(unitPrice),
+				purchasedAt,
+				supplier: supplier.trim() || undefined,
+				notes: notes.trim() || undefined,
+			},
+		});
+		setFeedTypeId("");
+		setQtyPurchased("");
+		setUnitPrice("");
+		setPurchasedAt("");
+		setSupplier("");
+		setNotes("");
+		setOpen(false);
+	};
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-center justify-between gap-2">
+				<CardTitle>{t("feedLots.title")}</CardTitle>
+				<div className="flex items-center gap-2">
+					<Select
+						value={stockFilter}
+						onValueChange={(value: "all" | "with_stock") =>
+							setStockFilter(value)
+						}
+					>
+						<SelectTrigger className="w-[130px]">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="with_stock">
+								{t("feedLots.stockFilter.withStock")}
+							</SelectItem>
+							<SelectItem value="all">
+								{t("feedLots.stockFilter.all")}
+							</SelectItem>
+						</SelectContent>
+					</Select>
+					<Dialog
+						open={open}
+						onOpenChange={setOpen}
+					>
+						<DialogTrigger asChild>
+							<Button
+								size="sm"
+								disabled={!hasFeedTypes}
+							>
+								{t("feedLots.newButton")}
+							</Button>
+						</DialogTrigger>
+						<DialogContent className="max-h-[90vh] overflow-y-auto">
+							<DialogTitle>{t("feedLots.modal.title")}</DialogTitle>
+							<DialogDescription>
+								{t("feedLots.modal.description")}
+							</DialogDescription>
+							<div className="space-y-3">
+								<Label>{t("feedLots.modal.feedType")}</Label>
+								<Select
+									value={feedTypeId}
+									onValueChange={setFeedTypeId}
+								>
+									<SelectTrigger className="w-full">
+										<SelectValue
+											placeholder={t("feedLots.modal.feedTypePlaceholder")}
+										/>
+									</SelectTrigger>
+									<SelectContent>
+										{feedTypes.map((item) => (
+											<SelectItem
+												key={item.id}
+												value={item.id}
+											>
+												{item.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+									<div>
+										<Label>{t("feedLots.modal.quantity")}</Label>
+										<Input
+											type="number"
+											min="0"
+											step="0.01"
+											value={qtyPurchased}
+											onChange={(event) => setQtyPurchased(event.target.value)}
+										/>
+									</div>
+									<div>
+										<Label>{t("feedLots.modal.unitPrice")}</Label>
+										<Input
+											type="number"
+											min="0"
+											step="0.01"
+											value={unitPrice}
+											onChange={(event) => setUnitPrice(event.target.value)}
+										/>
+									</div>
+								</div>
+								<div>
+									<Label>{t("feedLots.modal.purchaseDate")}</Label>
+									<Input
+										type="date"
+										value={purchasedAt}
+										onChange={(event) => setPurchasedAt(event.target.value)}
+									/>
+								</div>
+								<div>
+									<Label>{t("feedLots.modal.supplier")}</Label>
+									<Input
+										value={supplier}
+										onChange={(event) => setSupplier(event.target.value)}
+									/>
+								</div>
+								<div>
+									<Label>{t("feedLots.modal.notes")}</Label>
+									<Textarea
+										value={notes}
+										onChange={(event) => setNotes(event.target.value)}
+									/>
+								</div>
+								<Button
+									className="w-full"
+									disabled={isCreating}
+									onClick={() => void handleCreate()}
+								>
+									{t("feedLots.modal.create")}
+								</Button>
+							</div>
+						</DialogContent>
+					</Dialog>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				{!hasFeedTypes ? (
+					<div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+						{t("feedLots.adminManagedNotice")}
+					</div>
+				) : null}
+				<Select
+					value={filterFeedTypeId}
+					onValueChange={setFilterFeedTypeId}
+				>
+					<SelectTrigger className="w-full sm:w-[240px]">
+						<SelectValue placeholder={t("feedLots.filterPlaceholder")} />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">{t("feedLots.allFeedTypes")}</SelectItem>
+						{feedTypes.map((item) => (
+							<SelectItem
+								key={item.id}
+								value={item.id}
+							>
+								{item.name}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				{isPending ? (
+					<p className="text-sm text-muted-foreground">
+						{t("feedLots.loading")}
+					</p>
+				) : feedLots.length === 0 ? (
+					<p className="text-sm text-muted-foreground">{t("feedLots.empty")}</p>
+				) : (
+					<div className="space-y-2">
+						{feedLots.map((lot) => (
+							<div
+								key={lot.id}
+								className="rounded-md border p-3 flex items-center justify-between gap-3"
+							>
+								<div className="text-sm">
+									{/* Show feed type name */}
+									<p className="font-semibold">
+										{feedTypes.find((ft) => ft.id === lot.feedTypeId)?.name ||
+											t("feedLots.unknownFeedType")}
+									</p>
+									<p className="font-medium">
+										{t("feedLots.remaining", {
+											remaining: lot.qtyRemaining,
+											purchased: lot.qtyPurchased,
+										})}
+									</p>
+									<p className="text-muted-foreground">
+										{t("feedLots.purchasedLine", {
+											date: lot.purchasedAt,
+											price: lot.unitPrice.toFixed(2),
+										})}
+									</p>
+								</div>
+								{lot.qtyRemaining === lot.qtyPurchased ? (
+									<Dialog
+										open={deleteLotId === lot.id}
+										onOpenChange={(open) =>
+											setDeleteLotId(open ? lot.id : null)
+										}
+									>
+										<DialogTrigger asChild>
+											<Button
+												variant="ghost"
+												size="icon"
+												className="h-8 w-8 bg-destructive hover:bg-destructive/90 text-white"
+												disabled={isDeleting}
+												aria-label={t("feedLots.delete")}
+											>
+												<Trash2 className="h-4 w-4" />
+											</Button>
+										</DialogTrigger>
+										<DialogContent className="max-w-sm">
+											<DialogTitle>
+												{t("feedLots.deleteDialog.title")}
+											</DialogTitle>
+											<DialogDescription>
+												{t("feedLots.deleteDialog.description")}
+											</DialogDescription>
+											<div className="flex justify-end gap-2">
+												<Button
+													variant="outline"
+													onClick={() => setDeleteLotId(null)}
+													disabled={isDeleting}
+												>
+													{t("feedLots.deleteDialog.cancel")}
+												</Button>
+												<Button
+													variant="destructive"
+													disabled={isDeleting}
+													onClick={() =>
+														void deleteFeedLot({
+															feedLotId: lot.id,
+															farmId,
+														}).then(() => {
+															setDeleteLotId(null);
+														})
+													}
+												>
+													{t("feedLots.deleteDialog.confirm")}
+												</Button>
+											</div>
+										</DialogContent>
+									</Dialog>
+								) : null}
+							</div>
+						))}
+						{hasNextPage ? (
+							<div
+								ref={loadMoreRef}
+								className="h-2"
+							/>
+						) : null}
+						{isFetchingNextPage ? (
+							<p className="text-sm text-muted-foreground">
+								{t("feedLots.loadingMore")}
+							</p>
+						) : null}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+};

--- a/src/features/inventory/components/feed-reports-panel.tsx
+++ b/src/features/inventory/components/feed-reports-panel.tsx
@@ -1,0 +1,294 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { useGetFlocksPage } from "@/features/flock/api/flock-queries";
+import { useGetFeedLots } from "@/features/feed-lot/api/feed-lot-queries";
+import { useGetFeedTypes } from "@/features/feed-type/api/feed-type-queries";
+import {
+	useGetFeedCostByFlock,
+	useGetFeedCostByLot,
+} from "@/features/feed-report/api/feed-report-queries";
+
+interface FeedReportsPanelProps {
+	farmId: string;
+}
+
+export const FeedReportsPanel = ({ farmId }: FeedReportsPanelProps) => {
+	const { t, i18n } = useTranslation("inventory");
+	const [from, setFrom] = useState("");
+	const [to, setTo] = useState("");
+	const [flockId, setFlockId] = useState("all");
+	const [lotId, setLotId] = useState("all");
+
+	const { data: flockData } = useGetFlocksPage({ farmId, page: 1, limit: 100 });
+	const { data: feedTypes = [] } = useGetFeedTypes({ farmId });
+	const { data: lotData = [] } = useGetFeedLots({ farmId });
+	const flocks = flockData?.items ?? [];
+	const selectedLotId = lotId === "all" ? undefined : lotId;
+	const selectedFlockId = flockId === "all" ? undefined : flockId;
+
+	const { data: costByFlockResponse, isPending: isCostByFlockPending } =
+		useGetFeedCostByFlock({
+			farmId,
+			filters: {
+				from: from || undefined,
+				to: to || undefined,
+				flockId: selectedFlockId,
+			},
+		});
+
+	const { data: costByLot, isPending: isCostByLotPending } =
+		useGetFeedCostByLot({
+			farmId,
+			lotId: selectedLotId,
+		});
+
+	const money = useMemo(
+		() =>
+			new Intl.NumberFormat(i18n.language, {
+				style: "currency",
+				currency: "USD",
+				maximumFractionDigits: 2,
+			}),
+		[i18n.language],
+	);
+
+	const getFlockName = (flockId: string | null): string => {
+		if (!flockId) return t("feedReports.costByFlock.waste");
+		return flocks.find((f) => f.id === flockId)?.name ?? flockId;
+	};
+
+	const getFeedTypeName = (feedTypeId: string): string => {
+		return feedTypes.find((f) => f.id === feedTypeId)?.name ?? feedTypeId;
+	};
+
+	const costByFlockRows = costByFlockResponse?.flocks ?? [];
+
+	return (
+		<div className="grid grid-cols-1 gap-4">
+			<Card>
+				<CardHeader>
+					<CardTitle>{t("feedReports.filters.title")}</CardTitle>
+				</CardHeader>
+				<CardContent className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
+					<div>
+						<Label>{t("feedReports.filters.from")}</Label>
+						<Input
+							type="date"
+							value={from}
+							onChange={(event) => setFrom(event.target.value)}
+						/>
+					</div>
+					<div>
+						<Label>{t("feedReports.filters.to")}</Label>
+						<Input
+							type="date"
+							value={to}
+							onChange={(event) => setTo(event.target.value)}
+						/>
+					</div>
+					<div>
+						<Label>{t("feedReports.filters.flock")}</Label>
+						<Select
+							value={flockId}
+							onValueChange={setFlockId}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">
+									{t("feedReports.filters.all")}
+								</SelectItem>
+								{flocks.map((flock) => (
+									<SelectItem
+										key={flock.id}
+										value={flock.id}
+									>
+										{flock.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<div>
+						<Label>{t("feedReports.filters.lot")}</Label>
+						<Select
+							value={lotId}
+							onValueChange={setLotId}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">
+									{t("feedReports.filters.all")}
+								</SelectItem>
+								{lotData.map((lot) => (
+									<SelectItem
+										key={lot.id}
+										value={lot.id}
+									>
+										{lot.id.slice(0, 8)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>{t("feedReports.costByFlock.title")}</CardTitle>
+				</CardHeader>
+				<CardContent>
+					{isCostByFlockPending ? (
+						<p className="text-sm text-muted-foreground">
+							{t("feedReports.costByFlock.loading")}
+						</p>
+					) : costByFlockRows.length === 0 ? (
+						<p className="text-sm text-muted-foreground">
+							{t("feedReports.costByFlock.empty")}
+						</p>
+					) : (
+						<div className="space-y-3">
+							{costByFlockRows.map((row) => (
+								<div
+									key={row.flockId ?? "waste"}
+									className="rounded-md border p-3 text-sm space-y-2"
+								>
+									<div className="flex items-center justify-between">
+										<p className="font-semibold">{getFlockName(row.flockId)}</p>
+										<Badge variant="outline">
+											{t("feedReports.costByFlock.totalCost", {
+												value: money.format(row.totalCost),
+											})}
+										</Badge>
+									</div>
+									<p className="text-xs text-muted-foreground">
+										{t("feedReports.costByFlock.totalQty", {
+											value: (row.totalQty ?? 0).toFixed(2),
+										})}{" "}
+										kg
+									</p>
+									{row.byFeedType.length > 0 && (
+										<div className="pl-2 space-y-1 border-l border-dashed">
+											{row.byFeedType.map((feedType) => (
+												<div
+													key={feedType.feedTypeId}
+													className="text-xs text-muted-foreground"
+												>
+													<p>
+														{getFeedTypeName(feedType.feedTypeId)}:{" "}
+														{feedType.totalQty.toFixed(2)} kg @ $
+														{money
+															.format(feedType.totalCost / feedType.totalQty)
+															.replace(/\D/g, "")}
+														/kg
+													</p>
+												</div>
+											))}
+										</div>
+									)}
+								</div>
+							))}
+						</div>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>{t("feedReports.costByLot.title")}</CardTitle>
+				</CardHeader>
+				<CardContent>
+					{!selectedLotId ? (
+						<p className="text-sm text-muted-foreground">
+							{t("feedReports.costByLot.selectLot")}
+						</p>
+					) : isCostByLotPending ? (
+						<p className="text-sm text-muted-foreground">
+							{t("feedReports.costByLot.loading")}
+						</p>
+					) : !costByLot ? (
+						<p className="text-sm text-muted-foreground">
+							{t("feedReports.costByLot.empty")}
+						</p>
+					) : (
+						<div className="space-y-3">
+							<div className="rounded-md border p-3 text-sm space-y-2">
+								<div className="flex items-center justify-between">
+									<p className="font-semibold">
+										{getFeedTypeName(costByLot.feedTypeId)}
+									</p>
+									<Badge variant="outline">
+										{money.format(costByLot.totalCost)}
+									</Badge>
+								</div>
+								<div className="grid grid-cols-2 gap-2">
+									<div>
+										<p className="text-xs text-muted-foreground">Purchased</p>
+										<p className="text-sm font-medium">
+											{costByLot.qtyPurchased.toFixed(2)} kg
+										</p>
+									</div>
+									<div>
+										<p className="text-xs text-muted-foreground">Drawn</p>
+										<p className="text-sm font-medium">
+											{costByLot.qtyDrawn.toFixed(2)} kg
+										</p>
+									</div>
+									<div>
+										<p className="text-xs text-muted-foreground">Remaining</p>
+										<p className="text-sm font-medium">
+											{costByLot.qtyRemaining.toFixed(2)} kg
+										</p>
+									</div>
+									<div>
+										<p className="text-xs text-muted-foreground">Unit Cost</p>
+										<p className="text-sm font-medium">
+											{money.format(
+												costByLot.totalCost / (costByLot.qtyDrawn || 1),
+											)}
+										</p>
+									</div>
+								</div>
+							</div>
+
+							{costByLot.byFlock.length > 0 && (
+								<div className="rounded-md border p-3 text-sm space-y-2">
+									<p className="font-semibold text-xs">Consumption by flock</p>
+									<div className="space-y-1">
+										{costByLot.byFlock.map((flock) => (
+											<div
+												key={flock.flockId ?? "waste"}
+												className="flex justify-between text-xs text-muted-foreground"
+											>
+												<span>{getFlockName(flock.flockId)}</span>
+												<span>
+													{flock.totalQty.toFixed(2)} kg (
+													{money.format(flock.totalCost)})
+												</span>
+											</div>
+										))}
+									</div>
+								</div>
+							)}
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+};

--- a/src/features/inventory/components/feeding-schedule-panel.tsx
+++ b/src/features/inventory/components/feeding-schedule-panel.tsx
@@ -1,0 +1,362 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Calendar } from "@/components/ui/calendar";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { useGetFeedTypes } from "@/features/feed-type/api/feed-type-queries";
+import { useGetFlocksPage } from "@/features/flock/api/flock-queries";
+import {
+	useCreateFeedingSchedule,
+	useDeleteFeedingScheduleById,
+	useGetFeedingSchedules,
+	useUpdateFeedingScheduleById,
+} from "@/features/feeding-schedule/api/feeding-schedule-queries";
+import { formatDateByMonth } from "@/lib/dayjs/date-formats";
+
+interface FeedingSchedulePanelProps {
+	farmId: string;
+}
+
+export const FeedingSchedulePanel = ({ farmId }: FeedingSchedulePanelProps) => {
+	const { t } = useTranslation("inventory");
+	const [open, setOpen] = useState(false);
+	const [activeFilter, setActiveFilter] = useState<"all" | "active">("active");
+	const [flockId, setFlockId] = useState("");
+	const [feedTypeId, setFeedTypeId] = useState("");
+	const [qtyPerDay, setQtyPerDay] = useState("");
+	const [activeFrom, setActiveFrom] = useState<Date | null>(null);
+	const [activeTo, setActiveTo] = useState<Date | null>(null);
+	const { data: feedTypes = [] } = useGetFeedTypes({ farmId });
+	const { data: flockData } = useGetFlocksPage({ farmId, page: 1, limit: 100 });
+	const flocks = flockData?.items ?? [];
+	const hasBaseData = feedTypes.length > 0 && flocks.length > 0;
+	const filters = useMemo(
+		() => ({ activeOnly: activeFilter === "active" ? true : undefined }),
+		[activeFilter],
+	);
+	const { data: schedules = [], isPending } = useGetFeedingSchedules({
+		farmId,
+		filters,
+	});
+	const { mutateAsync: createSchedule, isPending: isCreating } =
+		useCreateFeedingSchedule();
+	const { mutateAsync: updateSchedule, isPending: isUpdating } =
+		useUpdateFeedingScheduleById();
+	const { mutateAsync: deleteSchedule, isPending: isDeleting } =
+		useDeleteFeedingScheduleById();
+
+	const resetForm = () => {
+		setFlockId("");
+		setFeedTypeId("");
+		setQtyPerDay("");
+		setActiveFrom(null);
+		setActiveTo(null);
+	};
+
+	const handleCreate = async () => {
+		if (!flockId || !feedTypeId || !qtyPerDay || !activeFrom) {
+			return;
+		}
+
+		await createSchedule({
+			farmId,
+			payload: {
+				flockId,
+				feedTypeId,
+				qtyPerDay: Number(qtyPerDay),
+				activeFrom: activeFrom.toISOString().split("T")[0],
+				activeTo: activeTo ? activeTo.toISOString().split("T")[0] : null,
+			},
+		});
+		resetForm();
+		setOpen(false);
+	};
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-center justify-between gap-2">
+				<CardTitle>{t("feedingSchedules.title")}</CardTitle>
+				<div className="flex items-center gap-2">
+					<Select
+						value={activeFilter}
+						onValueChange={(value: "all" | "active") => setActiveFilter(value)}
+					>
+						<SelectTrigger className="w-[120px]">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="active">
+								{t("feedingSchedules.filters.active")}
+							</SelectItem>
+							<SelectItem value="all">
+								{t("feedingSchedules.filters.all")}
+							</SelectItem>
+						</SelectContent>
+					</Select>
+					<Dialog
+						open={open}
+						onOpenChange={setOpen}
+					>
+						<DialogTrigger asChild>
+							<Button
+								size="sm"
+								disabled={!hasBaseData}
+							>
+								{t("feedingSchedules.newButton")}
+							</Button>
+						</DialogTrigger>
+						<DialogContent className="max-h-[90vh] overflow-y-auto">
+							<DialogTitle>{t("feedingSchedules.modal.title")}</DialogTitle>
+							<DialogDescription>
+								{t("feedingSchedules.modal.description")}
+							</DialogDescription>
+							<div className="space-y-3">
+								<div>
+									<Label>{t("feedingSchedules.modal.flock")}</Label>
+									<Select
+										value={flockId}
+										onValueChange={setFlockId}
+									>
+										<SelectTrigger className="w-full">
+											<SelectValue
+												placeholder={t(
+													"feedingSchedules.modal.flockPlaceholder",
+												)}
+											/>
+										</SelectTrigger>
+										<SelectContent>
+											{flocks.map((item) => (
+												<SelectItem
+													key={item.id}
+													value={item.id}
+												>
+													{item.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<div>
+									<Label>{t("feedingSchedules.modal.feedType")}</Label>
+									<Select
+										value={feedTypeId}
+										onValueChange={setFeedTypeId}
+									>
+										<SelectTrigger className="w-full">
+											<SelectValue
+												placeholder={t(
+													"feedingSchedules.modal.feedTypePlaceholder",
+												)}
+											/>
+										</SelectTrigger>
+										<SelectContent>
+											{feedTypes.map((item) => (
+												<SelectItem
+													key={item.id}
+													value={item.id}
+												>
+													{item.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<div>
+									<Label>{t("feedingSchedules.modal.qtyPerDay")}</Label>
+									<Input
+										type="number"
+										min="0"
+										step="0.01"
+										value={qtyPerDay}
+										onChange={(event) => setQtyPerDay(event.target.value)}
+									/>
+								</div>
+								<div>
+									<Label>{t("feedingSchedules.modal.activeFrom")}</Label>
+									<Popover>
+										<PopoverTrigger asChild>
+											<Button
+												variant="outline"
+												className="w-full justify-start text-left font-normal"
+											>
+												{activeFrom
+													? formatDateByMonth(
+															activeFrom.toISOString().split("T")[0],
+														)
+													: t("feedingSchedules.modal.selectDate")}
+											</Button>
+										</PopoverTrigger>
+										<PopoverContent
+											align="start"
+											className="w-auto p-0"
+										>
+											<Calendar
+												mode="single"
+												selected={activeFrom || undefined}
+												onSelect={(date) => setActiveFrom(date || null)}
+												disabled={(date) => date < new Date()}
+												required
+											/>
+										</PopoverContent>
+									</Popover>
+								</div>
+								<div>
+									<Label>{t("feedingSchedules.modal.activeTo")}</Label>
+									<Popover>
+										<PopoverTrigger asChild>
+											<Button
+												variant="outline"
+												className="w-full justify-start text-left font-normal"
+											>
+												{activeTo
+													? formatDateByMonth(
+															activeTo.toISOString().split("T")[0],
+														)
+													: t("feedingSchedules.modal.optional")}
+											</Button>
+										</PopoverTrigger>
+										<PopoverContent
+											align="start"
+											className="w-auto p-0"
+										>
+											<Calendar
+												mode="single"
+												selected={activeTo || undefined}
+												onSelect={(date) => setActiveTo(date || null)}
+												disabled={(date) => date < (activeFrom ?? new Date())}
+												required={false}
+											/>
+										</PopoverContent>
+									</Popover>
+								</div>
+								<Button
+									className="w-full"
+									disabled={isCreating}
+									onClick={() => void handleCreate()}
+								>
+									{t("feedingSchedules.modal.create")}
+								</Button>
+							</div>
+						</DialogContent>
+					</Dialog>
+				</div>
+			</CardHeader>
+			<CardContent>
+				{!hasBaseData ? (
+					<div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+						{t("feedingSchedules.missingBaseData")}
+					</div>
+				) : isPending ? (
+					<p className="text-sm text-muted-foreground">
+						{t("feedingSchedules.loading")}
+					</p>
+				) : schedules.length === 0 ? (
+					<p className="text-sm text-muted-foreground">
+						{t("feedingSchedules.empty")}
+					</p>
+				) : (
+					<div className="space-y-2">
+						{schedules.map((schedule) => {
+							const flockName =
+								flocks.find((item) => item.id === schedule.flockId)?.name ??
+								schedule.flock?.name ??
+								t("feedingSchedules.unknownFlock");
+							const feedTypeName =
+								feedTypes.find((item) => item.id === schedule.feedTypeId)
+									?.name ??
+								schedule.feedType?.name ??
+								t("feedingSchedules.unknownFeedType");
+							const isActive =
+								!schedule.activeTo || new Date(schedule.activeTo) > new Date();
+
+							return (
+								<div
+									key={schedule.id}
+									className="rounded-md border p-3 flex items-start justify-between gap-3"
+								>
+									<div className="text-sm">
+										<p className="font-semibold">{flockName}</p>
+										<p className="text-muted-foreground">{feedTypeName}</p>
+										<p className="font-medium">
+											{t("feedingSchedules.item.qtyPerDay", {
+												qty: schedule.qtyPerDay,
+											})}
+										</p>
+										<p className="text-xs text-muted-foreground">
+											{t("feedingSchedules.item.period", {
+												from: formatDateByMonth(schedule.activeFrom),
+												to: schedule.activeTo
+													? formatDateByMonth(schedule.activeTo)
+													: t("feedingSchedules.status.ongoing"),
+											})}
+										</p>
+										<Badge variant={isActive ? "default" : "secondary"}>
+											{isActive
+												? t("feedingSchedules.status.active")
+												: t("feedingSchedules.status.inactive")}
+										</Badge>
+									</div>
+									<div className="flex flex-col gap-2">
+										{isActive && (
+											<Button
+												variant="outline"
+												size="sm"
+												disabled={isUpdating}
+												onClick={() =>
+													void updateSchedule({
+														farmId,
+														feedingScheduleId: schedule.id,
+														payload: {
+															activeTo: new Date().toISOString().split("T")[0],
+														},
+													})
+												}
+											>
+												{t("feedingSchedules.actions.close")}
+											</Button>
+										)}
+										<Button
+											variant="destructive"
+											size="sm"
+											disabled={isDeleting}
+											onClick={() =>
+												void deleteSchedule({
+													farmId,
+													feedingScheduleId: schedule.id,
+												})
+											}
+										>
+											{t("feedingSchedules.actions.delete")}
+										</Button>
+									</div>
+								</div>
+							);
+						})}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+};

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -69,6 +69,14 @@ import expensesEN from "./en/expenses.json";
 import expensesES from "./es/expenses.json";
 import flocksEN from "./en/flocks.json";
 import flocksES from "./es/flocks.json";
+import feedTypesEN from "./en/feed-types.json";
+import feedTypesES from "./es/feed-types.json";
+import feedLotsEN from "./en/feed-lots.json";
+import feedLotsES from "./es/feed-lots.json";
+import feedConsumptionsEN from "./en/feed-consumptions.json";
+import feedConsumptionsES from "./es/feed-consumptions.json";
+import inventoryEN from "./en/inventory.json";
+import inventoryES from "./es/inventory.json";
 
 export const defaultNS = "login";
 
@@ -113,6 +121,10 @@ i18next
 				bottomTabNav: bottomTabNavEN,
 				expenses: expensesEN,
 				flocks: flocksEN,
+				feedTypes: feedTypesEN,
+				feedLots: feedLotsEN,
+				feedConsumptions: feedConsumptionsEN,
+				inventory: inventoryEN,
 			},
 			es: {
 				login: loginES,
@@ -149,6 +161,10 @@ i18next
 				bottomTabNav: bottomTabNavES,
 				expenses: expensesES,
 				flocks: flocksES,
+				feedTypes: feedTypesES,
+				feedLots: feedLotsES,
+				feedConsumptions: feedConsumptionsES,
+				inventory: inventoryES,
 			},
 		},
 		defaultNS,

--- a/src/lib/i18n/en/bottom-tab-nav.json
+++ b/src/lib/i18n/en/bottom-tab-nav.json
@@ -2,9 +2,12 @@
     "ariaLabel": "Main navigation",
     "tabs": {
         "dashboard": "Dashboard",
+        "livestock": "Livestock",
         "animals": "Animals",
         "flocks": "Flocks",
+        "finance": "Finance",
         "expenses": "Financial",
+        "inventory": "Inventory",
         "tasks": "Tasks",
         "profile": "Profile"
     }

--- a/src/lib/i18n/en/expenses.json
+++ b/src/lib/i18n/en/expenses.json
@@ -30,10 +30,26 @@
     "button": "Filters",
     "typeLabel": "Type",
     "speciesLabel": "Species",
+    "groupByLabel": "Group by",
+    "periodLabel": "Period",
     "fromLabel": "From",
     "toLabel": "To",
     "allTypes": "All types",
     "allSpecies": "All species",
+    "allGroupBy": "Default",
+    "allPeriods": "All periods",
+    "groupByOptions": {
+      "day": "Day",
+      "week": "Week",
+      "month": "Month",
+      "year": "Year"
+    },
+    "periodOptions": {
+      "7d": "Last 7 days",
+      "30d": "Last 30 days",
+      "3m": "Last 3 months",
+      "1y": "Last year"
+    },
     "clear": "Clear filters",
     "apply": "Apply",
     "clearDate": "Clear",
@@ -45,7 +61,9 @@
     "species": "Species",
     "createdAt": "Created",
     "notProvided": "-",
-    "noDescription": "No description"
+    "noDescription": "No description",
+    "systemGenerated": "Auto from inventory",
+    "systemGeneratedLocked": "Managed by inventory"
   },
   "summary": {
     "income": "Income",

--- a/src/lib/i18n/en/feed-consumptions.json
+++ b/src/lib/i18n/en/feed-consumptions.json
@@ -1,0 +1,6 @@
+{
+  "toast": {
+    "createSuccess": "Feed consumption recorded successfully",
+    "deleteSuccess": "Feed consumption deleted successfully"
+  }
+}

--- a/src/lib/i18n/en/feed-lots.json
+++ b/src/lib/i18n/en/feed-lots.json
@@ -1,0 +1,7 @@
+{
+  "toast": {
+    "createSuccess": "Feed lot created successfully",
+    "updateSuccess": "Feed lot updated successfully",
+    "deleteSuccess": "Feed lot deleted successfully"
+  }
+}

--- a/src/lib/i18n/en/feed-types.json
+++ b/src/lib/i18n/en/feed-types.json
@@ -1,0 +1,7 @@
+{
+  "toast": {
+    "createSuccess": "Feed type created successfully",
+    "updateSuccess": "Feed type updated successfully",
+    "deleteSuccess": "Feed type deleted successfully"
+  }
+}

--- a/src/lib/i18n/en/flocks.json
+++ b/src/lib/i18n/en/flocks.json
@@ -107,15 +107,22 @@
     "title": "Flock detail",
     "description": "Track flock activity and production",
     "loading": "Loading flock detail...",
+    "logToday": {
+      "action": "Log today's feeding",
+      "logging": "Logging...",
+      "success": "Today's feeding was logged"
+    },
     "events": {
       "title": "Flock events",
       "loading": "Loading events...",
+      "loadingMore": "Loading more events...",
       "empty": "No events found",
       "count": "Count: {{count}}"
     },
     "eggCollections": {
       "title": "Egg collections",
       "loading": "Loading egg collections...",
+      "loadingMore": "Loading more egg collections...",
       "empty": "No egg collections found",
       "layRate": "Lay rate: {{layRate}}%",
       "totals": "Total: {{totalEggs}} • Usable: {{usableEggs}} • Broken: {{brokenEggs}}",

--- a/src/lib/i18n/en/inventory.json
+++ b/src/lib/i18n/en/inventory.json
@@ -1,0 +1,157 @@
+{
+  "page": {
+    "title": "Inventory",
+    "description": "Manage feed lots and feeding records"
+  },
+  "tabs": {
+    "feedLots": "Feed Lots",
+    "feedLog": "Feed Log",
+    "feedingSchedules": "Schedules",
+    "feedReports": "Reports"
+  },
+  "feedLots": {
+    "title": "Feed Lots",
+    "stockFilter": {
+      "withStock": "With stock",
+      "all": "All"
+    },
+    "newButton": "New lot",
+    "modal": {
+      "title": "Create feed lot",
+      "description": "Record a feed purchase batch.",
+      "feedType": "Feed type",
+      "feedTypePlaceholder": "Select feed type",
+      "quantity": "Quantity (kg)",
+      "unitPrice": "Unit price",
+      "purchaseDate": "Purchase date",
+      "supplier": "Supplier",
+      "notes": "Notes",
+      "create": "Create"
+    },
+    "adminManagedNotice": "Feed types are managed by app administrators. Ask an admin to add at least one feed type before creating lots.",
+    "filterPlaceholder": "Filter by feed type",
+    "allFeedTypes": "All feed types",
+    "loading": "Loading feed lots...",
+    "loadingMore": "Loading more lots...",
+    "empty": "No lots found.",
+    "remaining": "{{remaining}} / {{purchased}} kg remaining",
+    "purchasedLine": "Purchased {{date}} - ${{price}} /kg",
+    "delete": "Delete",
+    "unknownFeedType": "Unknown feed type",
+    "deleteDialog": {
+      "title": "Delete feed lot?",
+      "description": "This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete"
+    }
+  },
+  "feedLog": {
+    "title": "Feed Log",
+    "newButton": "Log feeding",
+    "modal": {
+      "title": "Log feed event",
+      "description": "Record feeding, waste, transfer, or adjustment.",
+      "feedType": "Feed type",
+      "feedTypePlaceholder": "Select feed type",
+      "reason": "Reason",
+      "flock": "Flock",
+      "noFlock": "No flock",
+      "quantity": "Quantity (kg)",
+      "date": "Date",
+      "notes": "Notes",
+      "create": "Create"
+    },
+    "reasonOptions": {
+      "feeding": "Feeding",
+      "waste": "Waste",
+      "transfer": "Transfer",
+      "adjustment": "Adjustment"
+    },
+    "adminManagedNotice": "Feed types are managed by app administrators. Ask an admin to add at least one feed type before logging feed events.",
+    "loading": "Loading feed log...",
+    "loadingMore": "Loading more feed events...",
+    "empty": "No feed events recorded.",
+    "itemTitle": "{{qty}} kg - {{reason}}",
+    "itemSubtitle": "{{date}} - Cost ${{cost}}",
+    "delete": "Delete",
+    "deleteDialog": {
+      "title": "Delete feed record?",
+      "description": "This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete"
+    }
+  },
+  "feedingSchedules": {
+    "title": "Feeding Schedules",
+    "newButton": "New schedule",
+    "loading": "Loading feeding schedules...",
+    "empty": "No schedules found.",
+    "missingBaseData": "You need feed types and flocks before creating schedules.",
+    "unknownFlock": "Unknown flock",
+    "unknownFeedType": "Unknown feed type",
+    "filters": {
+      "active": "Active",
+      "all": "All"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "actions": {
+      "close": "Close",
+      "delete": "Delete"
+    },
+    "item": {
+      "qtyPerDay": "{{qty}} kg / day",
+      "period": "{{from}} to {{to}}"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive",
+      "ongoing": "Ongoing"
+    },
+    "modal": {
+      "title": "Create feeding schedule",
+      "description": "Set the daily feed target and active period for a flock.",
+      "flock": "Flock",
+      "flockPlaceholder": "Select flock",
+      "feedType": "Feed type",
+      "feedTypePlaceholder": "Select feed type",
+      "qtyPerDay": "Daily quantity (kg)",
+      "activeFrom": "Active from",
+      "activeTo": "Active to (optional)",
+      "selectDate": "Select date",
+      "optional": "Optional",
+      "create": "Create"
+    },
+    "toast": {
+      "createSuccess": "Feeding schedule created",
+      "updateSuccess": "Feeding schedule updated",
+      "deleteSuccess": "Feeding schedule deleted"
+    }
+  },
+  "feedReports": {
+    "filters": {
+      "title": "Report filters",
+      "from": "From",
+      "to": "To",
+      "flock": "Flock",
+      "lot": "Lot",
+      "all": "All"
+    },
+    "costByFlock": {
+      "title": "Cost by flock",
+      "loading": "Loading flock cost report...",
+      "empty": "No flock cost data for the selected filters.",
+      "waste": "Waste / Transfers",
+      "totalCost": "{{value}}",
+      "totalQty": "{{value}}"
+    },
+    "costByLot": {
+      "title": "Cost by lot",
+      "selectLot": "Select a lot to see detailed costs.",
+      "loading": "Loading lot cost report...",
+      "empty": "No lot data found."
+    }
+  }
+}

--- a/src/lib/i18n/es/bottom-tab-nav.json
+++ b/src/lib/i18n/es/bottom-tab-nav.json
@@ -2,9 +2,12 @@
     "ariaLabel": "Navegación principal",
     "tabs": {
         "dashboard": "Inicio",
+        "livestock": "Ganadería",
         "animals": "Animales",
         "flocks": "Lotes",
-        "expenses": "Finanzas",
+        "finance": "Finanzas",
+        "expenses": "Gastos",
+        "inventory": "Inventario",
         "tasks": "Tareas",
         "profile": "Perfil"
     }

--- a/src/lib/i18n/es/expenses.json
+++ b/src/lib/i18n/es/expenses.json
@@ -30,10 +30,26 @@
     "button": "Filtros",
     "typeLabel": "Tipo",
     "speciesLabel": "Especie",
+    "groupByLabel": "Agrupar por",
+    "periodLabel": "Periodo",
     "fromLabel": "Desde",
     "toLabel": "Hasta",
     "allTypes": "Todos los tipos",
     "allSpecies": "Todas las especies",
+    "allGroupBy": "Predeterminado",
+    "allPeriods": "Todos los periodos",
+    "groupByOptions": {
+      "day": "Dia",
+      "week": "Semana",
+      "month": "Mes",
+      "year": "Ano"
+    },
+    "periodOptions": {
+      "7d": "Ultimos 7 dias",
+      "30d": "Ultimos 30 dias",
+      "3m": "Ultimos 3 meses",
+      "1y": "Ultimo ano"
+    },
     "clear": "Limpiar filtros",
     "apply": "Aplicar",
     "clearDate": "Limpiar",
@@ -45,7 +61,9 @@
     "species": "Especie",
     "createdAt": "Creado",
     "notProvided": "-",
-    "noDescription": "Sin descripcion"
+    "noDescription": "Sin descripcion",
+    "systemGenerated": "Auto desde inventario",
+    "systemGeneratedLocked": "Gestionado por inventario"
   },
   "summary": {
     "income": "Ingresos",

--- a/src/lib/i18n/es/feed-consumptions.json
+++ b/src/lib/i18n/es/feed-consumptions.json
@@ -1,0 +1,6 @@
+{
+  "toast": {
+    "createSuccess": "Consumo de alimento registrado exitosamente",
+    "deleteSuccess": "Consumo de alimento eliminado exitosamente"
+  }
+}

--- a/src/lib/i18n/es/feed-lots.json
+++ b/src/lib/i18n/es/feed-lots.json
@@ -1,0 +1,7 @@
+{
+  "toast": {
+    "createSuccess": "Lote de alimento creado exitosamente",
+    "updateSuccess": "Lote de alimento actualizado exitosamente",
+    "deleteSuccess": "Lote de alimento eliminado exitosamente"
+  }
+}

--- a/src/lib/i18n/es/feed-types.json
+++ b/src/lib/i18n/es/feed-types.json
@@ -1,0 +1,7 @@
+{
+  "toast": {
+    "createSuccess": "Tipo de alimento creado exitosamente",
+    "updateSuccess": "Tipo de alimento actualizado exitosamente",
+    "deleteSuccess": "Tipo de alimento eliminado exitosamente"
+  }
+}

--- a/src/lib/i18n/es/flocks.json
+++ b/src/lib/i18n/es/flocks.json
@@ -107,15 +107,22 @@
     "title": "Detalle del lote",
     "description": "Sigue la actividad y producción del lote",
     "loading": "Cargando detalle del lote...",
+    "logToday": {
+      "action": "Registrar alimentacion de hoy",
+      "logging": "Registrando...",
+      "success": "La alimentacion de hoy fue registrada"
+    },
     "events": {
       "title": "Eventos del lote",
       "loading": "Cargando eventos...",
+      "loadingMore": "Cargando mas eventos...",
       "empty": "No se encontraron eventos",
       "count": "Cantidad: {{count}}"
     },
     "eggCollections": {
       "title": "Recolecciones de huevos",
       "loading": "Cargando recolecciones...",
+      "loadingMore": "Cargando mas recolecciones...",
       "empty": "No se encontraron recolecciones",
       "layRate": "Tasa de postura: {{layRate}}%",
       "totals": "Total: {{totalEggs}} • Aprovechables: {{usableEggs}} • Rotos: {{brokenEggs}}",

--- a/src/lib/i18n/es/inventory.json
+++ b/src/lib/i18n/es/inventory.json
@@ -1,0 +1,157 @@
+{
+  "page": {
+    "title": "Inventario",
+    "description": "Gestiona lotes de alimento y registros de alimentacion"
+  },
+  "tabs": {
+    "feedLots": "Lotes de alimento",
+    "feedLog": "Registro de alimento",
+    "feedingSchedules": "Programacion",
+    "feedReports": "Reportes"
+  },
+  "feedLots": {
+    "title": "Lotes de alimento",
+    "stockFilter": {
+      "withStock": "Con stock",
+      "all": "Todos"
+    },
+    "newButton": "Nuevo lote",
+    "modal": {
+      "title": "Crear lote de alimento",
+      "description": "Registra un lote de compra de alimento.",
+      "feedType": "Tipo de alimento",
+      "feedTypePlaceholder": "Selecciona un tipo de alimento",
+      "quantity": "Cantidad (kg)",
+      "unitPrice": "Precio unitario",
+      "purchaseDate": "Fecha de compra",
+      "supplier": "Proveedor",
+      "notes": "Notas",
+      "create": "Crear"
+    },
+    "adminManagedNotice": "Los tipos de alimento los administra el equipo de la app. Pide a un administrador que agregue al menos un tipo de alimento antes de crear lotes.",
+    "filterPlaceholder": "Filtrar por tipo de alimento",
+    "allFeedTypes": "Todos los tipos de alimento",
+    "loading": "Cargando lotes de alimento...",
+    "loadingMore": "Cargando mas lotes...",
+    "empty": "No se encontraron lotes.",
+    "remaining": "{{remaining}} / {{purchased}} kg restantes",
+    "purchasedLine": "Comprado {{date}} - ${{price}} /kg",
+    "delete": "Eliminar",
+    "unknownFeedType": "Tipo de alimento desconocido",
+    "deleteDialog": {
+      "title": "Eliminar lote de alimento?",
+      "description": "Esta accion no se puede deshacer.",
+      "cancel": "Cancelar",
+      "confirm": "Eliminar"
+    }
+  },
+  "feedLog": {
+    "title": "Registro de alimento",
+    "newButton": "Registrar consumo",
+    "modal": {
+      "title": "Registrar evento de alimento",
+      "description": "Registra alimentacion, merma, traslado o ajuste.",
+      "feedType": "Tipo de alimento",
+      "feedTypePlaceholder": "Selecciona un tipo de alimento",
+      "reason": "Motivo",
+      "flock": "Lote",
+      "noFlock": "Sin lote",
+      "quantity": "Cantidad (kg)",
+      "date": "Fecha",
+      "notes": "Notas",
+      "create": "Crear"
+    },
+    "reasonOptions": {
+      "feeding": "Alimentacion",
+      "waste": "Merma",
+      "transfer": "Traslado",
+      "adjustment": "Ajuste"
+    },
+    "adminManagedNotice": "Los tipos de alimento los administra el equipo de la app. Pide a un administrador que agregue al menos un tipo de alimento antes de registrar eventos.",
+    "loading": "Cargando registro de alimento...",
+    "loadingMore": "Cargando mas eventos de alimento...",
+    "empty": "No hay eventos de alimento registrados.",
+    "itemTitle": "{{qty}} kg - {{reason}}",
+    "itemSubtitle": "{{date}} - Costo ${{cost}}",
+    "delete": "Eliminar",
+    "deleteDialog": {
+      "title": "Eliminar registro de alimento?",
+      "description": "Esta accion no se puede deshacer.",
+      "cancel": "Cancelar",
+      "confirm": "Eliminar"
+    }
+  },
+  "feedingSchedules": {
+    "title": "Programacion de alimentacion",
+    "newButton": "Nueva programacion",
+    "loading": "Cargando programaciones...",
+    "empty": "No se encontraron programaciones.",
+    "missingBaseData": "Necesitas tipos de alimento y lotes para crear programaciones.",
+    "unknownFlock": "Lote desconocido",
+    "unknownFeedType": "Tipo de alimento desconocido",
+    "filters": {
+      "active": "Activas",
+      "all": "Todas"
+    },
+    "status": {
+      "active": "Activa",
+      "inactive": "Inactiva"
+    },
+    "actions": {
+      "close": "Cerrar",
+      "delete": "Eliminar"
+    },
+    "item": {
+      "qtyPerDay": "{{qty}} kg / dia",
+      "period": "{{from}} a {{to}}"
+    },
+    "status": {
+      "active": "Activa",
+      "inactive": "Inactiva",
+      "ongoing": "En curso"
+    },
+    "modal": {
+      "title": "Crear programacion de alimentacion",
+      "description": "Define la meta diaria de alimento y el periodo activo para un lote.",
+      "flock": "Lote",
+      "flockPlaceholder": "Selecciona lote",
+      "feedType": "Tipo de alimento",
+      "feedTypePlaceholder": "Selecciona tipo de alimento",
+      "qtyPerDay": "Cantidad diaria (kg)",
+      "activeFrom": "Activa desde",
+      "activeTo": "Activa hasta (opcional)",
+      "selectDate": "Selecciona fecha",
+      "optional": "Opcional",
+      "create": "Crear"
+    },
+    "toast": {
+      "createSuccess": "Programacion creada",
+      "updateSuccess": "Programacion actualizada",
+      "deleteSuccess": "Programacion eliminada"
+    }
+  },
+  "feedReports": {
+    "filters": {
+      "title": "Filtros de reporte",
+      "from": "Desde",
+      "to": "Hasta",
+      "flock": "Lote",
+      "lot": "Compra",
+      "all": "Todos"
+    },
+    "costByFlock": {
+      "title": "Costo por lote",
+      "loading": "Cargando reporte por lote...",
+      "empty": "No hay datos para los filtros seleccionados.",
+      "waste": "Desperdicio / Transferencias",
+      "totalCost": "{{value}}",
+      "totalQty": "{{value}}"
+    },
+    "costByLot": {
+      "title": "Costo por compra",
+      "selectLot": "Selecciona una compra para ver costos detallados.",
+      "loading": "Cargando reporte por compra...",
+      "empty": "No se encontro informacion de la compra."
+    }
+  }
+}

--- a/src/lib/i18n/resources.ts
+++ b/src/lib/i18n/resources.ts
@@ -32,6 +32,10 @@ import privateLayout from "./en/private-layout.json";
 import bottomTabNav from "./en/bottom-tab-nav.json";
 import expenses from "./en/expenses.json";
 import flocks from "./en/flocks.json";
+import feedTypes from "./en/feed-types.json";
+import feedLots from "./en/feed-lots.json";
+import feedConsumptions from "./en/feed-consumptions.json";
+import inventory from "./en/inventory.json";
 
 //Only bring one of the json files as structure reference.
 const resources = {
@@ -69,6 +73,10 @@ const resources = {
 	bottomTabNav,
 	expenses,
 	flocks,
+	feedTypes,
+	feedLots,
+	feedConsumptions,
+	inventory,
 } as const;
 
 export default resources;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as PrivatePrivatelayoutRouteImport } from './routes/_private/_pri
 import { Route as PublicLayoutSignupRouteImport } from './routes/_public/_layout/signup'
 import { Route as PublicLayoutLoginRouteImport } from './routes/_public/_layout/login'
 import { Route as PrivatePrivatelayoutFarmFarmIdTasksRouteImport } from './routes/_private/_privatelayout/farm/$farmId/tasks'
+import { Route as PrivatePrivatelayoutFarmFarmIdInventoryRouteImport } from './routes/_private/_privatelayout/farm/$farmId/inventory'
 import { Route as PrivatePrivatelayoutFarmFarmIdFlocksRouteImport } from './routes/_private/_privatelayout/farm/$farmId/flocks'
 import { Route as PrivatePrivatelayoutFarmFarmIdFarmsRouteImport } from './routes/_private/_privatelayout/farm/$farmId/farms'
 import { Route as PrivatePrivatelayoutFarmFarmIdFarmMembersRouteImport } from './routes/_private/_privatelayout/farm/$farmId/farm-members'
@@ -52,6 +53,12 @@ const PrivatePrivatelayoutFarmFarmIdTasksRoute =
   PrivatePrivatelayoutFarmFarmIdTasksRouteImport.update({
     id: '/farm/$farmId/tasks',
     path: '/farm/$farmId/tasks',
+    getParentRoute: () => PrivatePrivatelayoutRoute,
+  } as any)
+const PrivatePrivatelayoutFarmFarmIdInventoryRoute =
+  PrivatePrivatelayoutFarmFarmIdInventoryRouteImport.update({
+    id: '/farm/$farmId/inventory',
+    path: '/farm/$farmId/inventory',
     getParentRoute: () => PrivatePrivatelayoutRoute,
   } as any)
 const PrivatePrivatelayoutFarmFarmIdFlocksRoute =
@@ -120,6 +127,7 @@ export interface FileRoutesByFullPath {
   '/farm/$farmId/farm-members': typeof PrivatePrivatelayoutFarmFarmIdFarmMembersRoute
   '/farm/$farmId/farms': typeof PrivatePrivatelayoutFarmFarmIdFarmsRoute
   '/farm/$farmId/flocks': typeof PrivatePrivatelayoutFarmFarmIdFlocksRouteWithChildren
+  '/farm/$farmId/inventory': typeof PrivatePrivatelayoutFarmFarmIdInventoryRoute
   '/farm/$farmId/tasks': typeof PrivatePrivatelayoutFarmFarmIdTasksRoute
   '/farm/$farmId/flocks/$flockId': typeof PrivatePrivatelayoutFarmFarmIdFlocksFlockIdRoute
   '/farm/$farmId/species/': typeof PrivatePrivatelayoutFarmFarmIdSpeciesIndexRoute
@@ -135,6 +143,7 @@ export interface FileRoutesByTo {
   '/farm/$farmId/farm-members': typeof PrivatePrivatelayoutFarmFarmIdFarmMembersRoute
   '/farm/$farmId/farms': typeof PrivatePrivatelayoutFarmFarmIdFarmsRoute
   '/farm/$farmId/flocks': typeof PrivatePrivatelayoutFarmFarmIdFlocksRouteWithChildren
+  '/farm/$farmId/inventory': typeof PrivatePrivatelayoutFarmFarmIdInventoryRoute
   '/farm/$farmId/tasks': typeof PrivatePrivatelayoutFarmFarmIdTasksRoute
   '/farm/$farmId/flocks/$flockId': typeof PrivatePrivatelayoutFarmFarmIdFlocksFlockIdRoute
   '/farm/$farmId/species': typeof PrivatePrivatelayoutFarmFarmIdSpeciesIndexRoute
@@ -153,6 +162,7 @@ export interface FileRoutesById {
   '/_private/_privatelayout/farm/$farmId/farm-members': typeof PrivatePrivatelayoutFarmFarmIdFarmMembersRoute
   '/_private/_privatelayout/farm/$farmId/farms': typeof PrivatePrivatelayoutFarmFarmIdFarmsRoute
   '/_private/_privatelayout/farm/$farmId/flocks': typeof PrivatePrivatelayoutFarmFarmIdFlocksRouteWithChildren
+  '/_private/_privatelayout/farm/$farmId/inventory': typeof PrivatePrivatelayoutFarmFarmIdInventoryRoute
   '/_private/_privatelayout/farm/$farmId/tasks': typeof PrivatePrivatelayoutFarmFarmIdTasksRoute
   '/_private/_privatelayout/farm/$farmId/flocks/$flockId': typeof PrivatePrivatelayoutFarmFarmIdFlocksFlockIdRoute
   '/_private/_privatelayout/farm/$farmId/species/': typeof PrivatePrivatelayoutFarmFarmIdSpeciesIndexRoute
@@ -170,6 +180,7 @@ export interface FileRouteTypes {
     | '/farm/$farmId/farm-members'
     | '/farm/$farmId/farms'
     | '/farm/$farmId/flocks'
+    | '/farm/$farmId/inventory'
     | '/farm/$farmId/tasks'
     | '/farm/$farmId/flocks/$flockId'
     | '/farm/$farmId/species/'
@@ -185,6 +196,7 @@ export interface FileRouteTypes {
     | '/farm/$farmId/farm-members'
     | '/farm/$farmId/farms'
     | '/farm/$farmId/flocks'
+    | '/farm/$farmId/inventory'
     | '/farm/$farmId/tasks'
     | '/farm/$farmId/flocks/$flockId'
     | '/farm/$farmId/species'
@@ -202,6 +214,7 @@ export interface FileRouteTypes {
     | '/_private/_privatelayout/farm/$farmId/farm-members'
     | '/_private/_privatelayout/farm/$farmId/farms'
     | '/_private/_privatelayout/farm/$farmId/flocks'
+    | '/_private/_privatelayout/farm/$farmId/inventory'
     | '/_private/_privatelayout/farm/$farmId/tasks'
     | '/_private/_privatelayout/farm/$farmId/flocks/$flockId'
     | '/_private/_privatelayout/farm/$farmId/species/'
@@ -257,6 +270,13 @@ declare module '@tanstack/react-router' {
       path: '/farm/$farmId/tasks'
       fullPath: '/farm/$farmId/tasks'
       preLoaderRoute: typeof PrivatePrivatelayoutFarmFarmIdTasksRouteImport
+      parentRoute: typeof PrivatePrivatelayoutRoute
+    }
+    '/_private/_privatelayout/farm/$farmId/inventory': {
+      id: '/_private/_privatelayout/farm/$farmId/inventory'
+      path: '/farm/$farmId/inventory'
+      fullPath: '/farm/$farmId/inventory'
+      preLoaderRoute: typeof PrivatePrivatelayoutFarmFarmIdInventoryRouteImport
       parentRoute: typeof PrivatePrivatelayoutRoute
     }
     '/_private/_privatelayout/farm/$farmId/flocks': {
@@ -346,6 +366,7 @@ interface PrivatePrivatelayoutRouteChildren {
   PrivatePrivatelayoutFarmFarmIdFarmMembersRoute: typeof PrivatePrivatelayoutFarmFarmIdFarmMembersRoute
   PrivatePrivatelayoutFarmFarmIdFarmsRoute: typeof PrivatePrivatelayoutFarmFarmIdFarmsRoute
   PrivatePrivatelayoutFarmFarmIdFlocksRoute: typeof PrivatePrivatelayoutFarmFarmIdFlocksRouteWithChildren
+  PrivatePrivatelayoutFarmFarmIdInventoryRoute: typeof PrivatePrivatelayoutFarmFarmIdInventoryRoute
   PrivatePrivatelayoutFarmFarmIdTasksRoute: typeof PrivatePrivatelayoutFarmFarmIdTasksRoute
   PrivatePrivatelayoutFarmFarmIdSpeciesIndexRoute: typeof PrivatePrivatelayoutFarmFarmIdSpeciesIndexRoute
   PrivatePrivatelayoutFarmFarmIdSpeciesSpeciesIdAnimalsRoute: typeof PrivatePrivatelayoutFarmFarmIdSpeciesSpeciesIdAnimalsRoute
@@ -363,6 +384,8 @@ const PrivatePrivatelayoutRouteChildren: PrivatePrivatelayoutRouteChildren = {
     PrivatePrivatelayoutFarmFarmIdFarmsRoute,
   PrivatePrivatelayoutFarmFarmIdFlocksRoute:
     PrivatePrivatelayoutFarmFarmIdFlocksRouteWithChildren,
+  PrivatePrivatelayoutFarmFarmIdInventoryRoute:
+    PrivatePrivatelayoutFarmFarmIdInventoryRoute,
   PrivatePrivatelayoutFarmFarmIdTasksRoute:
     PrivatePrivatelayoutFarmFarmIdTasksRoute,
   PrivatePrivatelayoutFarmFarmIdSpeciesIndexRoute:

--- a/src/routes/_private/_privatelayout.tsx
+++ b/src/routes/_private/_privatelayout.tsx
@@ -10,6 +10,7 @@ import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { toast } from "sonner";
 import i18next from "i18next";
 import { useTranslation } from "react-i18next";
+import { useEffect } from "react";
 
 export const Route = createFileRoute("/_private/_privatelayout")({
 	loader: async ({ context }) => {
@@ -33,6 +34,19 @@ function PrivateLayout() {
 	const { data: userData, isLoading } = useGetUserProfile();
 	const { t } = useTranslation("privateLayout");
 
+	useEffect(() => {
+		const previousHtmlOverflow = document.documentElement.style.overflow;
+		const previousBodyOverflow = document.body.style.overflow;
+
+		document.documentElement.style.overflow = "hidden";
+		document.body.style.overflow = "hidden";
+
+		return () => {
+			document.documentElement.style.overflow = previousHtmlOverflow;
+			document.body.style.overflow = previousBodyOverflow;
+		};
+	}, []);
+
 	if (isLoading) {
 		return <div>{t("isLoadingMsg")}</div>;
 	}
@@ -41,10 +55,10 @@ function PrivateLayout() {
 	}
 
 	return (
-		<div className="bg-background h-screen w-screen flex flex-col">
+		<div className="bg-background h-dvh w-full flex flex-col overflow-hidden">
 			<div
 				id="app-scroll-container"
-				className="flex-1 overflow-auto pb-20"
+				className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain pb-20"
 			>
 				<Outlet />
 			</div>

--- a/src/routes/_private/_privatelayout/farm/$farmId/flocks/$flockId.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/flocks/$flockId.tsx
@@ -2,15 +2,17 @@ import { PageHeader } from "@/components/common/page-header";
 import { ScrollablePageLayout } from "@/components/layout/scrollable-page-layout";
 import { Button } from "@/components/ui/button";
 import {
-	useGetEggCollectionsPage,
+	useGetInfiniteEggCollections,
+	useGetInfiniteFlockEvents,
 	useGetFlockById,
-	useGetFlockEventsPage,
+	useLogTodaysFeeding,
 } from "@/features/flock/api/flock-queries";
 import { EggCollectionsList } from "@/features/flock/components/egg-collections-list";
 import { FlockEventsList } from "@/features/flock/components/flock-events-list";
 import { RecordEggCollectionModal } from "@/features/flock/components/record-egg-collection-modal";
 import { UpdateFlockCountModal } from "@/features/flock/components/update-flock-count-modal";
 import { createFileRoute, useParams } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute(
@@ -46,14 +48,18 @@ function RouteComponent() {
 		isError: isEventsError,
 		error: eventsError,
 		refetch: refetchEvents,
-	} = useGetFlockEventsPage({
+		hasNextPage: hasMoreEvents,
+		fetchNextPage: fetchMoreEvents,
+		isFetchingNextPage: isFetchingMoreEvents,
+	} = useGetInfiniteFlockEvents({
 		flockId: flockId!,
-		page: 1,
-		limit: 10,
+		limit: 5,
 	});
 
 	const isLayingFlock =
 		flock?.flockType === "layers" || flock?.flockType === "dual_purpose";
+	const { mutateAsync: logTodaysFeeding, isPending: isLoggingTodaysFeeding } =
+		useLogTodaysFeeding();
 
 	const {
 		data: eggCollectionData,
@@ -61,15 +67,78 @@ function RouteComponent() {
 		isError: isEggCollectionsError,
 		error: eggCollectionsError,
 		refetch: refetchEggCollections,
-	} = useGetEggCollectionsPage({
+		hasNextPage: hasMoreEggCollections,
+		fetchNextPage: fetchMoreEggCollections,
+		isFetchingNextPage: isFetchingMoreEggCollections,
+	} = useGetInfiniteEggCollections({
 		flockId: flockId!,
-		page: 1,
-		limit: 10,
+		limit: 5,
 	});
+
+	const eventsLoadMoreRef = useRef<HTMLDivElement | null>(null);
+	const eventsScrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const eggCollectionsLoadMoreRef = useRef<HTMLDivElement | null>(null);
+	const eggCollectionsScrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const target = eventsLoadMoreRef.current;
+		const root = eventsScrollContainerRef.current;
+		if (!target || !root || !hasMoreEvents) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const entry = entries[0];
+				if (!entry?.isIntersecting || isFetchingMoreEvents) {
+					return;
+				}
+
+				void fetchMoreEvents();
+			},
+			{ root, rootMargin: "200px" },
+		);
+
+		observer.observe(target);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [fetchMoreEvents, hasMoreEvents, isFetchingMoreEvents]);
+
+	useEffect(() => {
+		const target = eggCollectionsLoadMoreRef.current;
+		const root = eggCollectionsScrollContainerRef.current;
+		if (!target || !root || !hasMoreEggCollections) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const entry = entries[0];
+				if (!entry?.isIntersecting || isFetchingMoreEggCollections) {
+					return;
+				}
+
+				void fetchMoreEggCollections();
+			},
+			{ root, rootMargin: "200px" },
+		);
+
+		observer.observe(target);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [
+		fetchMoreEggCollections,
+		hasMoreEggCollections,
+		isFetchingMoreEggCollections,
+	]);
 
 	return (
 		<ScrollablePageLayout
-			className="max-w-5xl mx-auto pb-24"
+			className="max-w-5xl mx-auto pb-0"
 			header={
 				<PageHeader
 					title={flock?.name ?? t("detail.title")}
@@ -120,12 +189,29 @@ function RouteComponent() {
 						</div>
 					</div>
 
-					<UpdateFlockCountModal
-						flock={flock!}
-						farmId={farmId!}
-						buttonClassName="h-11 w-full justify-center rounded-xl border border-border/50 bg-transparent font-bold text-foreground hover:bg-muted/50"
-						editorClassName="w-full min-w-0"
-					/>
+					<div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+						<UpdateFlockCountModal
+							flock={flock!}
+							farmId={farmId!}
+							buttonClassName="h-11 w-full justify-center rounded-xl border border-border/50 bg-transparent font-bold text-foreground hover:bg-muted/50"
+							editorClassName="w-full min-w-0"
+						/>
+						<Button
+							variant="outline"
+							className="h-11 rounded-xl"
+							disabled={isLoggingTodaysFeeding}
+							onClick={() =>
+								void logTodaysFeeding({
+									flockId: flockId!,
+									farmId: farmId!,
+								})
+							}
+						>
+							{isLoggingTodaysFeeding
+								? t("detail.logToday.logging")
+								: t("detail.logToday.action")}
+						</Button>
+					</div>
 
 					<section className="space-y-2">
 						<h2 className="text-h2">{t("detail.events.title")}</h2>
@@ -148,7 +234,23 @@ function RouteComponent() {
 								</div>
 							</div>
 						) : (
-							<FlockEventsList events={eventData?.items ?? []} />
+							<div
+								ref={eventsScrollContainerRef}
+								className="h-72 overflow-y-auto overscroll-contain pr-1"
+							>
+								<FlockEventsList events={eventData?.items ?? []} />
+								{hasMoreEvents ? (
+									<div
+										ref={eventsLoadMoreRef}
+										className="h-2"
+									/>
+								) : null}
+								{isFetchingMoreEvents ? (
+									<p className="text-sm text-muted-foreground">
+										{t("detail.events.loadingMore")}
+									</p>
+								) : null}
+							</div>
 						)}
 					</section>
 
@@ -184,11 +286,27 @@ function RouteComponent() {
 									</div>
 								</div>
 							) : (
-								<EggCollectionsList
-									eggCollections={eggCollectionData?.items ?? []}
-									flockId={flockId!}
-									farmId={farmId!}
-								/>
+								<div
+									ref={eggCollectionsScrollContainerRef}
+									className="h-72 overflow-y-auto overscroll-contain pr-1"
+								>
+									<EggCollectionsList
+										eggCollections={eggCollectionData?.items ?? []}
+										flockId={flockId!}
+										farmId={farmId!}
+									/>
+									{hasMoreEggCollections ? (
+										<div
+											ref={eggCollectionsLoadMoreRef}
+											className="h-2"
+										/>
+									) : null}
+									{isFetchingMoreEggCollections ? (
+										<p className="text-sm text-muted-foreground">
+											{t("detail.eggCollections.loadingMore")}
+										</p>
+									) : null}
+								</div>
 							)}
 						</section>
 					)}

--- a/src/routes/_private/_privatelayout/farm/$farmId/flocks/$flockId.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/flocks/$flockId.tsx
@@ -51,11 +51,6 @@ function RouteComponent() {
 		page: 1,
 		limit: 10,
 	});
-	const { data: historyEventData } = useGetFlockEventsPage({
-		flockId: flockId!,
-		page: 1,
-		limit: 1000,
-	});
 
 	const isLayingFlock =
 		flock?.flockType === "layers" || flock?.flockType === "dual_purpose";
@@ -193,8 +188,6 @@ function RouteComponent() {
 									eggCollections={eggCollectionData?.items ?? []}
 									flockId={flockId!}
 									farmId={farmId!}
-									flockInitialCount={flock?.initialCount ?? 0}
-									flockEventsForHistory={historyEventData?.items ?? []}
 								/>
 							)}
 						</section>

--- a/src/routes/_private/_privatelayout/farm/$farmId/inventory.tsx
+++ b/src/routes/_private/_privatelayout/farm/$farmId/inventory.tsx
@@ -1,0 +1,66 @@
+import { PageHeader } from "@/components/common/page-header";
+import { ScrollablePageLayout } from "@/components/layout/scrollable-page-layout";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FeedConsumptionPanel } from "@/features/inventory/components/feed-consumption-panel";
+import { FeedLotPanel } from "@/features/inventory/components/feed-lot-panel";
+import { FeedReportsPanel } from "@/features/inventory/components/feed-reports-panel";
+import { FeedingSchedulePanel } from "@/features/inventory/components/feeding-schedule-panel";
+import { createFileRoute, useParams } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+
+export const Route = createFileRoute(
+	"/_private/_privatelayout/farm/$farmId/inventory",
+)({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { farmId } = useParams({ strict: false });
+	const { t } = useTranslation("inventory");
+
+	if (!farmId) {
+		return null;
+	}
+
+	return (
+		<ScrollablePageLayout
+			className="max-w-5xl mx-auto pb-24"
+			header={
+				<PageHeader
+					title={t("page.title")}
+					description={t("page.description")}
+				/>
+			}
+		>
+			<Tabs
+				defaultValue="feed-lots"
+				className="space-y-4"
+			>
+				<TabsList className="grid w-full grid-cols-2 md:grid-cols-4 h-auto gap-1">
+					<TabsTrigger value="feed-lots">{t("tabs.feedLots")}</TabsTrigger>
+					<TabsTrigger value="consumptions">{t("tabs.feedLog")}</TabsTrigger>
+					<TabsTrigger value="schedules">
+						{t("tabs.feedingSchedules")}
+					</TabsTrigger>
+					<TabsTrigger value="reports">{t("tabs.feedReports")}</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="feed-lots">
+					<FeedLotPanel farmId={farmId} />
+				</TabsContent>
+
+				<TabsContent value="consumptions">
+					<FeedConsumptionPanel farmId={farmId} />
+				</TabsContent>
+
+				<TabsContent value="schedules">
+					<FeedingSchedulePanel farmId={farmId} />
+				</TabsContent>
+
+				<TabsContent value="reports">
+					<FeedReportsPanel farmId={farmId} />
+				</TabsContent>
+			</Tabs>
+		</ScrollablePageLayout>
+	);
+}


### PR DESCRIPTION
## Summary
Add feed inventory capabilities across API/query layers, UI panels, route wiring, and localization.

## What changed
- Added feed domain modules: feed types, feed lots, feed consumptions, feed reports, and feeding schedules.
- Added inventory UI panels and farm inventory route integration.
- Added English and Spanish i18n resources for inventory/feed features.
- Added supporting docs for backend brief and feature guide.
- Included related fixes on this branch: flock detail scroll containment and expense feed-lot support.

## Validation performed
- Lint: Passed
- Build: Passed

## Risks/notes
- Out-of-scope vs branch name: branch name references flock requests, but PR also includes inventory/feed feature delivery and expense updates.
- Build reports existing bundle-size warnings for large chunks.