### PR TITLE
Add material asset creation dialog

### DIFF
--- a/src/features/livestock/components/create-material-asset-dialog.tsx
+++ b/src/features/livestock/components/create-material-asset-dialog.tsx
@@ -1,0 +1,172 @@
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateLivestockAsset } from "@/features/livestock/api/livestock-queries";
+import { cn } from "@/lib/utils";
+
+interface CreateMaterialAssetDialogProps {
+	farmId: string;
+	triggerClassName?: string;
+}
+
+const EMPTY_FORM = {
+	name: "",
+	location: "",
+	description: "",
+};
+
+export function CreateMaterialAssetDialog({
+	farmId,
+	triggerClassName,
+}: CreateMaterialAssetDialogProps) {
+	const [open, setOpen] = useState(false);
+	const [name, setName] = useState(EMPTY_FORM.name);
+	const [location, setLocation] = useState(EMPTY_FORM.location);
+	const [description, setDescription] = useState(EMPTY_FORM.description);
+	const [errorMessage, setErrorMessage] = useState("");
+	const createMaterialMutation = useCreateLivestockAsset();
+
+	const resetForm = () => {
+		setName(EMPTY_FORM.name);
+		setLocation(EMPTY_FORM.location);
+		setDescription(EMPTY_FORM.description);
+		setErrorMessage("");
+	};
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			resetForm();
+		}
+	};
+
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+
+		if (!farmId) return;
+		if (!name.trim()) {
+			setErrorMessage("Ingresa el nombre del material.");
+			return;
+		}
+
+		setErrorMessage("");
+
+		try {
+			await createMaterialMutation.mutateAsync({
+				farmId,
+				data: {
+					name: name.trim(),
+					location: location.trim() || undefined,
+					description: description.trim() || undefined,
+					kind: "material",
+					mode: "aggregated",
+				},
+			});
+
+			handleOpenChange(false);
+		} catch {
+			setErrorMessage(
+				"No se pudo crear el material. Revisa los datos e intenta de nuevo.",
+			);
+		}
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={handleOpenChange}
+		>
+			<DialogTrigger asChild>
+				<Button
+					variant="outline"
+					className={cn(
+						"rounded-full border-(--v2-border) bg-white px-3 py-1.5 text-xs font-semibold",
+						triggerClassName,
+					)}
+				>
+					Nuevo material
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="w-[calc(100vw-2rem)] max-w-128 p-4 sm:p-6">
+				<DialogHeader>
+					<DialogTitle>Crear material</DialogTitle>
+					<DialogDescription>
+						Registra un nuevo material para esta granja.
+					</DialogDescription>
+				</DialogHeader>
+
+				<form
+					className="space-y-4"
+					onSubmit={handleSubmit}
+				>
+					<div className="space-y-2">
+						<Label htmlFor="material-name">Nombre</Label>
+						<Input
+							id="material-name"
+							value={name}
+							onChange={(event) => setName(event.target.value)}
+							placeholder="Nombre del material"
+							required
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="material-location">Ubicacion</Label>
+						<Input
+							id="material-location"
+							value={location}
+							onChange={(event) => setLocation(event.target.value)}
+							placeholder="Ubicacion"
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="material-description">Descripcion</Label>
+						<Textarea
+							id="material-description"
+							value={description}
+							onChange={(event) => setDescription(event.target.value)}
+							placeholder="Descripcion"
+							rows={4}
+						/>
+					</div>
+
+					{errorMessage ? (
+						<p className="text-sm text-red-700">{errorMessage}</p>
+					) : null}
+
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => handleOpenChange(false)}
+							disabled={createMaterialMutation.isPending}
+						>
+							Cancelar
+						</Button>
+						<Button
+							type="submit"
+							disabled={createMaterialMutation.isPending}
+						>
+							{createMaterialMutation.isPending
+								? "Creando..."
+								: "Crear material"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/livestock/pages/livestock-kind-page.tsx
+++ b/src/features/livestock/pages/livestock-kind-page.tsx
@@ -6,6 +6,7 @@ import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useGetUserProfile } from "@/features/auth/api/auth-queries";
 import { ASSET_KIND_OPTIONS } from "@/features/livestock/constants/asset-kind-options";
 import { AssetKindMedal } from "@/features/livestock/components/asset-kind-medal";
+import { CreateMaterialAssetDialog } from "@/features/livestock/components/create-material-asset-dialog";
 import {
 	useDeleteLivestockAssetById,
 	useListLivestockAssetsByFarmId,
@@ -350,6 +351,8 @@ export function LivestockKindPage({
 					>
 						Nuevo lote
 					</Link>
+				) : selectedKind === "material" ? (
+					<CreateMaterialAssetDialog farmId={farmId} />
 				) : null}
 			</div>
 


### PR DESCRIPTION
## Summary
Restore a direct material creation flow from the livestock kind page after the quick action entry point was removed.

## What changed
- added a local material creation dialog component for livestock material assets
- wired the material header action on the livestock kind page to open that dialog
- submitted new materials through the existing livestock asset creation mutation

## Validation performed
- Lint: Passed
- Build: Passed

## Risks/notes
- Material creation still uses aggregated mode, matching the previous quick-create behavior.
- Repository lint warnings are pre-existing and unrelated to this change.